### PR TITLE
Replace deprecated mouse_event with SendInput

### DIFF
--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -753,7 +753,13 @@ MSWindowsDesks::deskThread(void* vdesk)
 		case SYNERGY_MSG_FAKE_WHEEL:
 			// XXX -- add support for x-axis scrolling
 			if (msg.lParam != 0) {
-				mouse_event(MOUSEEVENTF_WHEEL, 0, 0, (DWORD)msg.lParam, 0);
+				//mouse_event(MOUSEEVENTF_WHEEL, 0, 0, (DWORD)msg.lParam, 0);
+				INPUT input;
+				memset(&input, 0, sizeof(INPUT)); //don't remove this or the screensaver will show-up, strange bug
+				input.type = 0; //INPUT_MOUSE
+				input.mi.mouseData = (DWORD)msg.lParam;
+				input.mi.dwFlags = 0x0800; //MouseWheel
+				SendInput(1, &input, sizeof(INPUT));
 			}
 			break;
 

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -755,9 +755,9 @@ MSWindowsDesks::deskThread(void* vdesk)
 			if (msg.lParam != 0) {
 				//mouse_event(MOUSEEVENTF_WHEEL, 0, 0, (DWORD)msg.lParam, 0);
 				INPUT input;
-				memset(&input, 0, sizeof(INPUT)); //don't remove this or the screensaver will show-up, strange bug
 				input.type = 0; //INPUT_MOUSE
 				input.mi.mouseData = (DWORD)msg.lParam;
+				input.mi.time = 0;
 				input.mi.dwFlags = 0x0800; //MouseWheel
 				SendInput(1, &input, sizeof(INPUT));
 			}

--- a/src/lib/platform/MSWindowsDesks.cpp
+++ b/src/lib/platform/MSWindowsDesks.cpp
@@ -755,9 +755,9 @@ MSWindowsDesks::deskThread(void* vdesk)
 			if (msg.lParam != 0) {
 				//mouse_event(MOUSEEVENTF_WHEEL, 0, 0, (DWORD)msg.lParam, 0);
 				INPUT input;
+				memset(&input, 0, sizeof(INPUT));
 				input.type = 0; //INPUT_MOUSE
 				input.mi.mouseData = (DWORD)msg.lParam;
-				input.mi.time = 0;
 				input.mi.dwFlags = 0x0800; //MouseWheel
 				SendInput(1, &input, sizeof(INPUT));
 			}


### PR DESCRIPTION
Many games don't work well when we send the mouse wheel input using mouse_event, using SendInput make them respond correctly to this kind of event. Btw I think that we should remove all mouse_event and keybd_event call and use only SendInput as mouse_event and keybd_event are deprecated.
