### PR TITLE
Checkbox to set 'preserveFocus' in Screen Settings

### DIFF
--- a/src/gui/gui.ts
+++ b/src/gui/gui.ts
@@ -853,6 +853,11 @@ To automatically trust this fingerprint for future connections, click Yes. To re
         <source>Fix XTest for Xinerama</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="res/ScreenSettingsDialogBase.ui" line="468"/>
+        <source>Preserve window focus</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ScreenSetupModel</name>

--- a/src/gui/res/ScreenSettingsDialogBase.ui
+++ b/src/gui/res/ScreenSettingsDialogBase.ui
@@ -463,6 +463,16 @@
          </widget>
         </item>
         <item row="4" column="0">
+         <widget class="QCheckBox" name="m_pCheckBoxFocus">
+          <property name="text">
+           <string>Preserve window focus</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
          <spacer>
           <property name="orientation">
            <enum>Qt::Vertical</enum>

--- a/src/gui/src/BaseConfig.cpp
+++ b/src/gui/src/BaseConfig.cpp
@@ -33,7 +33,8 @@ const char* BaseConfig::m_FixNames[] =
 	"halfDuplexCapsLock",
 	"halfDuplexNumLock",
 	"halfDuplexScrollLock",
-	"xtestIsXineramaUnaware"
+	"xtestIsXineramaUnaware",
+	"preserveFocus"
 };
 
 const char* BaseConfig::m_SwitchCornerNames[] =

--- a/src/gui/src/BaseConfig.h
+++ b/src/gui/src/BaseConfig.h
@@ -29,7 +29,7 @@ class BaseConfig
 	public:
 		enum Modifier { DefaultMod = -1, Shift, Ctrl, Alt, Meta, Super, None, NumModifiers };
 		enum SwitchCorner { TopLeft, TopRight, BottomLeft, BottomRight, NumSwitchCorners };
-		enum Fix { CapsLock, NumLock, ScrollLock, XTest, NumFixes };
+		enum Fix { CapsLock, NumLock, ScrollLock, XTest, Focus, NumFixes };
 
 	protected:
 		BaseConfig() {}

--- a/src/gui/src/ScreenSettingsDialog.cpp
+++ b/src/gui/src/ScreenSettingsDialog.cpp
@@ -57,6 +57,7 @@ ScreenSettingsDialog::ScreenSettingsDialog(QWidget* parent, Screen* pScreen) :
 	m_pCheckBoxNumLock->setChecked(m_pScreen->fix(Screen::NumLock));
 	m_pCheckBoxScrollLock->setChecked(m_pScreen->fix(Screen::ScrollLock));
 	m_pCheckBoxXTest->setChecked(m_pScreen->fix(Screen::XTest));
+	m_pCheckBoxFocus->setChecked(m_pScreen->fix(Screen::Focus));
 }
 
 void ScreenSettingsDialog::accept()
@@ -104,6 +105,7 @@ void ScreenSettingsDialog::accept()
 	m_pScreen->setFix(Screen::NumLock, m_pCheckBoxNumLock->isChecked());
 	m_pScreen->setFix(Screen::ScrollLock, m_pCheckBoxScrollLock->isChecked());
 	m_pScreen->setFix(Screen::XTest, m_pCheckBoxXTest->isChecked());
+	m_pScreen->setFix(Screen::Focus, m_pCheckBoxFocus->isChecked());
 
 	QDialog::accept();
 }


### PR DESCRIPTION
Tested that: 
- It does indeed add the preserveFocus option to the resulting config file when enabled.
- GUI stays aesthetically pleasing.
