### PR TITLE
Map JIS Keys to make OS X synergy server comfortable.

### DIFF
--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -114,6 +114,12 @@ static const KeyEntry	s_controlKeys[] = {
 	{ kKeyMeta_L,		s_superVK },
 	{ kKeyMeta_R,		s_superVK }, // 61
 
+	{ '\\',			kVK_JIS_Yen },
+	{ '_',			kVK_JIS_Underscore },
+	{ ',',			kVK_JIS_KeypadComma },
+	{ kKeyZenkaku,		kVK_JIS_Eisu },
+	{ kKeyHenkan,		kVK_JIS_Kana },
+
 	// toggle modifiers
 	{ kKeyNumLock,		s_numLockVK },
 	{ kKeyCapsLock,		s_capsLockVK },


### PR DESCRIPTION
I've upgraded to Pro license and SSL support was nice.
Though still mac's Kana/Eisu key problem isn't solved so I'm posting this. 

Maps Carbon's JIS keys to make synergy with Japanese mac keyboard comfortable.
Based on [this blog post](http://d.hatena.ne.jp/saburahu/20150818/1439916939)'s patch.

Adds key mappings of following table:

|Synergy Key|Mac Key|
|-------------|---------|
|`\`|`￥`(Yen sign)|
|`_`|`_`(underscore placed to `ろ` key)|
|`,`|`,`(comma placed to `ね` key)|
|`全角/半角`(Zenkaku/Hankaku)|`英数`(Eisu)|
|`変換`(Henkan)|`かな`(Kana)|

I know the last 2 mappings is just a workaround so any better solutions?
On Windows they toggles the IME, though in macOS it changes the IME.