### PR TITLE
Correct using the wrong plist path

### DIFF
--- a/ext/toolchain/commands1.py
+++ b/ext/toolchain/commands1.py
@@ -788,7 +788,7 @@ class InternalCommands:
 				for dir in dirs:
 					if dir.startswith("Qt"):
 						shutil.copy(
-							frameworkRootDir + "/" + dir + "/Contents/Info.plist",
+							frameworkRootDir + "/" + dir + "/Resources/Info.plist",
 							target + "/" + dir + "/Resources/")
 
 	def symlink(self, source, target):
@@ -823,7 +823,6 @@ class InternalCommands:
 						if dir.startswith("Qt"):
 							self.try_chdir(target + "/" + dir +"/Versions")
 							self.symlink("5", "Current")
-							self.move("../Resources", "5")
 							self.restore_chdir()
 
 							self.try_chdir(target + "/" + dir)


### PR DESCRIPTION
Fix macOS Sierra build errors.

Fixes #5719