### PR TITLE
Set appropriate umask when writing SSL certificate

### DIFF
--- a/src/gui/src/SslCertificate.cpp
+++ b/src/gui/src/SslCertificate.cpp
@@ -19,6 +19,11 @@
 
 #include "Fingerprint.h"
 
+#if defined(Q_OS_LINUX)
+#include <sys/types.h>
+#include <sys/stat.h>
+#endif
+
 #include <QProcess>
 #include <QDir>
 #include <QCoreApplication>
@@ -136,7 +141,15 @@ void SslCertificate::generateCertificate()
         arguments.append("-out");
         arguments.append(filename);
 
-        if (!runTool(arguments)) {
+#if defined(Q_OS_LINUX)
+        mode_t prevMask = umask(0);
+        umask(prevMask|S_IXUSR|S_IRWXG|S_IRWXO);
+#endif
+        bool generateSuccess = runTool(arguments);
+#if defined(Q_OS_LINUX)
+        umask(prevMask);
+#endif
+        if (!generateSuccess) {
             return;
         }
 


### PR DESCRIPTION
Fix for #6135 by setting umask before calling openssl.
previous umask is restored after call.

This doesn't account for files already created (synergy currently does nothing if the file already exists.)

I also noticed in testing a newer version of openssl on Debian (1.1.0f) that it was already setting permissions appropriately. I can't find a relevant changelog entry from Debian or OpenSSL so I'm not sure where the change was introduced.