### PR TITLE
Fix building against libressl

### DIFF
--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -807,7 +807,7 @@ SecureSocket::showSecureCipherInfo()
         showCipherStackDesc(sStack);
     }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 	// m_ssl->m_ssl->session->ciphers is not forward compatable,
 	// In future release of OpenSSL, it's not visible,
     STACK_OF(SSL_CIPHER) * cStack = m_ssl->m_ssl->session->ciphers;


### PR DESCRIPTION
a73b65431b755aec1f007d11feccd017cc04af6c added a compile time condition
to use SSL_get_client_ciphers() on newer versions of ssl.  libressl
doesn't have this function and sets its OPENSSL_VERSION_NUMBER to
0x20000000L, which is causing compilation to fail.