### PR TITLE
PVS-Studio small fix

### DIFF
--- a/src/cmd/core/main.cpp
+++ b/src/cmd/core/main.cpp
@@ -28,7 +28,7 @@ int
 main(int argc, char** argv) 
 {
     // TODO(andrew): use existing arg parse code
-    bool server, client;
+    bool server = false, client = false;
     if (argc > 1) {
         server = std::string(argv[1]) == "--server";
         client = std::string(argv[1]) == "--client";

--- a/src/lib/base/String.cpp
+++ b/src/lib/base/String.cpp
@@ -174,7 +174,7 @@ findReplaceAll(
 }
 
 String
-removeFileExt(String filename)
+removeFileExt(const String& filename)
 {
     size_t dot = filename.find_last_of('.');
 

--- a/src/lib/base/String.h
+++ b/src/lib/base/String.h
@@ -69,7 +69,7 @@ void findReplaceAll(String& subject, const String& find, const String& replace);
 /*!
 Finds the last dot and remove all characters from the dot to the end
 */
-String removeFileExt(String filename);
+String removeFileExt(const String& filename);
 
 //! Convert into hexdecimal
 /*!

--- a/src/lib/core/Clipboard.cpp
+++ b/src/lib/core/Clipboard.cpp
@@ -43,7 +43,7 @@ Clipboard::empty()
 
     // clear all data
     for (SInt32 index = 0; index < kNumFormats; ++index) {
-        m_data[index]  = "";
+        m_data[index].clear();
         m_added[index] = false;
     }
 

--- a/src/lib/core/KeyMap.cpp
+++ b/src/lib/core/KeyMap.cpp
@@ -999,7 +999,7 @@ KeyMap::addKeystrokes(EKeystroke type, const KeyItem& keyItem,
             }
 
             // if no more keys for this modifier then deactivate modifier
-            if (activeModifiers.count(keyItem.m_generates) == 0) {
+            if (activeModifiers.find(keyItem.m_generates) == activeModifiers.end()) {
                 currentState &= ~keyItem.m_generates;
             }
         }
@@ -1245,7 +1245,7 @@ KeyMap::parseModifiers(String& x, KeyModifierMask& mask)
             String::size_type tb = x.find_first_not_of(" \t");
             String::size_type te = x.find_last_not_of(" \t");
             if (tb == String::npos) {
-                x = "";
+                x.clear();
             }
             else {
                 x = x.substr(tb, te - tb + 1);

--- a/src/lib/core/KeyState.cpp
+++ b/src/lib/core/KeyState.cpp
@@ -687,7 +687,7 @@ KeyState::fakeKeyUp(KeyButton serverID)
             ++i;
             m_activeModifiers.erase(tmp);
 
-            if (m_activeModifiers.count(mask) == 0) {
+            if (m_activeModifiers.find(mask) == m_activeModifiers.end()) {
                 // no key for modifier is down so deactivate modifier
                 m_mask &= ~mask;
                 LOG((CLOG_DEBUG1 "new state %04x", m_mask));

--- a/src/lib/core/KeyState.h
+++ b/src/lib/core/KeyState.h
@@ -161,7 +161,7 @@ private:
     class ButtonToKeyLess {
     public:
         bool operator()(const synergy::KeyMap::ButtonToKeyMap::value_type& a,
-                        const synergy::KeyMap::ButtonToKeyMap::value_type b) const
+                        const synergy::KeyMap::ButtonToKeyMap::value_type& b) const
         {
             return (a.first < b.first);
         }

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -568,7 +568,7 @@ MSWindowsWatchdog::getActiveDesktop(LPSECURITY_ATTRIBUTES security)
 } 
 
 void
-MSWindowsWatchdog::testOutput(String buffer)
+MSWindowsWatchdog::testOutput(const String& buffer)
 {
     // HACK: check standard output seems hacky.
     size_t i = buffer.find(g_activeDesktop);

--- a/src/lib/platform/MSWindowsWatchdog.h
+++ b/src/lib/platform/MSWindowsWatchdog.h
@@ -58,7 +58,7 @@ private:
     BOOL                doStartProcess(String& command, HANDLE userToken, LPSECURITY_ATTRIBUTES sa);
     void                sendSas();
     void                getActiveDesktop(LPSECURITY_ATTRIBUTES security);
-    void                testOutput(String buffer);
+    void                testOutput(const String& buffer);
 
 private:
     Thread*                m_thread;

--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -960,7 +960,7 @@ Config::readSectionLinks(ConfigReadContext& s)
 			// in the range [0,100] and start < end.  if not given the
 			// interval is taken to be (0,100).
 			String::size_type i = 0;
-			String side, dstScreen, srcArgString, dstArgString;
+			String side, dstScreen;
 			ConfigReadContext::ArgList srcArgs, dstArgs;
 			s.parseNameWithArgs("link", line, "=", i, side, srcArgs);
 			++i;
@@ -1791,7 +1791,6 @@ operator<<(std::ostream& s, const Config& config)
 	s << "end" << std::endl;
 
 	// links section
-	String neighbor;
 	s << "section: links" << std::endl;
 	for (Config::const_iterator screen = config.begin();
 								screen != config.end(); ++screen) {


### PR DESCRIPTION
V801 Decreased performance. It is better to redefine the second function argument as a reference. Consider replacing 'const .. b' with 'const .. &b'. keystate.h 164
V813 Decreased performance. The 'filename' argument should probably be rendered as a constant reference. string.cpp 177
V813 Decreased performance. The 'buffer' argument should probably be rendered as a constant reference. mswindowswatchdog.cpp 571
V813 Decreased performance. The 'filename' argument should probably be rendered as a constant reference. string.cpp 177
V813 Decreased performance. The 'buffer' argument should probably be rendered as a constant reference. mswindowswatchdog.cpp 571
V815 Decreased performance. Consider replacing the expression 'm_data[index] = ""' with 'm_data[index].clear()'. clipboard.cpp 46
V815 Decreased performance. Consider replacing the expression 'x = ""' with 'x.clear()'. keymap.cpp 1248
V812 Decreased performance. Ineffective use of the 'count' function. It can possibly be replaced by the call to the 'find' function. keystate.cpp 690
V812 Decreased performance. Ineffective use of the 'count' function. It can possibly be replaced by the call to the 'find' function. keymap.cpp 1002
V808 'srcArgString' object of 'basic_string' type was created but was not utilized. config.cpp 963
V808 'dstArgString' object of 'basic_string' type was created but was not utilized. config.cpp 963
V808 'neighbor' object of 'basic_string' type was created but was not utilized. config.cpp 1794
V614 Potentially uninitialized variable 'server' used. main.cpp 48
V614 Potentially uninitialized variable 'client' used. main.cpp 52