### PR TITLE
synergy.conf.example: clarify comments

### DIFF
--- a/doc/synergy.conf.example
+++ b/doc/synergy.conf.example
@@ -4,28 +4,29 @@
 # line.  comments may appear anywhere the syntax permits.
 
 section: screens
-	# three hosts named:  moe, larry, and curly
+	# three hosts, named "moe", "larry", and "curly"
 	moe:
 	larry:
 	curly:
 end
 
 section: links
-	# larry is to the right of moe and curly is above moe
+	# for moe, larry is to the right and curly is above.
 	moe:
 		right = larry
 		up    = curly
 
-	# moe is to the left of larry and curly is above larry.
-	# note that curly is above both moe and larry and moe
-	# and larry have a symmetric connection (they're in
-	# opposite directions of each other).
+	# for larry, moe is to the left and curly is also above.
+	# note that curly is above both moe and larry
+	# and that the connection between moe and larry is symmetric
+	# (i.e. they're in opposite directions of each other).
 	larry:
 		left  = moe
 		up    = curly
 
-	# larry is below curly.  if you move up from moe and then
-	# down, you'll end up on larry.
+	# for curly, larry is below.
+	# if you move up from moe, and then move down,
+	# you'll end up on larry, not back at moe.
 	curly:
 		down  = larry
 end


### PR DESCRIPTION
instead of saying apparently absolute statements
like "Foo is to the right of Bar",
use relative phrasing "for Bar, Foo is to the right".
This makes it clearer that the configuration file
does not describe a globally consistent spatial arrangement
but rather a set of areas that can be linked in arbitrary ways.