### PR TITLE
Initialize XWindowsScreen to offscreen for secondary displays

### DIFF
--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -102,7 +102,7 @@ XWindowsScreen::XWindowsScreen(
 	m_display(nullptr),
 	m_root(None),
 	m_window(None),
-	m_isOnScreen(true),
+	m_isOnScreen(isPrimary),
 	m_x(0), m_y(0),
 	m_w(0), m_h(0),
 	m_xCenter(0), m_yCenter(0),


### PR DESCRIPTION
XWindowsScreen::m_isOnScreen currently initializes to true for all
screens, meaning that every screen assumes it currently has control of
the shared mouse pointer when it starts up. For the primary (server)
screen, this is appropriate; when synergy starts, the local mouse should
still move the cursor on the local screen.

However, for secondary screens, this is incorrect; when the client
connects, it does _not_ have control of the shared mouse pointer, as the
server's mouse still moves the server's cursor.

This doesn't make much difference in most cases, as the secondary screen
behaves almost identically whether m_isOnScreen is true or false;
however, the local input detection code will only fire if the variable
is false, meaning that once the client connects, it first has to gain
the cursor and then lose it before it will detect local input.

Since the Synergy 2.0 service relies on synergy-core's local input
detection to determine when to switch to server mode, this means that a
Linux desktop can only ever claim primary if the shared cursor has at
some point moved to that screen, then left it.

This fixes the bug so that local input on a Linux desktop can reclaim
the primary role immediately after losing it.

Fixes #6248.