### PR TITLE
Add support for latin 's' and 't' with comma below

### DIFF
--- a/src/lib/platform/XWindowsUtil.cpp
+++ b/src/lib/platform/XWindowsUtil.cpp
@@ -933,6 +933,10 @@ struct codepair {
 { XK_oe,                          0x0153 }, /* LATIN SMALL LIGATURE OE */
 { XK_Ydiaeresis,                  0x0178 }, /* LATIN CAPITAL LETTER Y WITH DIAERESIS */
 { XK_EuroSign,                    0x20ac }, /* EURO SIGN */
+{ 0x1000218,                      0x0218},  /* LATIN CAPITAL LETTER S WITH COMMA BELOW */
+{ 0x1000219,                      0x0219},  /* LATIN SMALL LETTER S WITH COMMA BELOW */
+{ 0x100021a,                      0x021a},  /* LATIN CAPITAL LETTER T WITH COMMA BELOW */
+{ 0x100021b,                      0x021b},  /* LATIN CAPITAL LETTER T WITH COMMA BELOW */
 
 /* combining dead keys */
 { XK_dead_abovedot,               0x0307 }, /* COMBINING DOT ABOVE */


### PR DESCRIPTION
These codes were not supported at all, presumably due to being introduced
only in Unicode 3.0.