### PR TITLE
Replace deprecated qt5_use_modules

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -49,7 +49,7 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 endif()
 endif()
 
-qt5_use_modules (synergy Core Widgets Network)
+target_link_libraries (synergy Qt5::Core Qt5::Widgets Qt5::Network)
 target_compile_definitions (synergy PRIVATE -DSYNERGY_VERSION_STAGE="${SYNERGY_VERSION_STAGE}")
 target_compile_definitions (synergy PRIVATE -DSYNERGY_REVISION="${SYNERGY_REVISION}")
 


### PR DESCRIPTION
Since qt5_use_modules is deprecated in newer cmake versions
use target_link_libraries with Qt5:: targets instead.
see: http://doc.qt.io/qt-5/cmake-manual.html