### PR TITLE
Add missing headers to build against Qt 5.11.0

### DIFF
--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -26,6 +26,8 @@
 #include <QtCore>
 #include <QtGui>
 
+#include <QButtonGroup>
+
 ActionDialog::ActionDialog(QWidget* parent, ServerConfig& config, Hotkey& hotkey, Action& action) :
     QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint),
     Ui::ActionDialogBase(),

--- a/src/gui/src/ScreenSetupView.cpp
+++ b/src/gui/src/ScreenSetupView.cpp
@@ -23,6 +23,8 @@
 #include <QtCore>
 #include <QtGui>
 
+#include <QHeaderView>
+
 ScreenSetupView::ScreenSetupView(QWidget* parent) :
     QTableView(parent)
 {


### PR DESCRIPTION
Some Qt headers are not included in QtGui anymore. So add them where
needed to get synergy 1.10 to build on windows with Qt 5.11.0