### PR TITLE
Fixed missing SSL_get_client_ciphers with LibreSSL

### DIFF
--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -808,12 +808,13 @@ SecureSocket::showSecureCipherInfo()
         showCipherStackDesc(sStack);
     }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 	// m_ssl->m_ssl->session->ciphers is not forward compatable,
 	// In future release of OpenSSL, it's not visible,
+	// however, LibreSSL still uses this.
     STACK_OF(SSL_CIPHER) * cStack = m_ssl->m_ssl->session->ciphers;
 #else
-	// Use SSL_get_client_ciphers() for newer versions
+	// Use SSL_get_client_ciphers() for newer versions of OpenSSL.
 	STACK_OF(SSL_CIPHER) * cStack = SSL_get_client_ciphers(m_ssl->m_ssl);
 #endif
 	if (cStack == NULL) {


### PR DESCRIPTION
This patch is for the 1.X versions. 2.X does not have this problem.
Weirdly enough, LibreSSL has a high enough version, yet does not feature SSL_get_client_ciphers.