### PR TITLE
Fixed client focus-grabbing issue

### DIFF
--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -344,7 +344,7 @@ XWindowsScreen::leave()
 	XMapRaised(m_display, m_window);
 
 	// grab the mouse and keyboard, if primary and possible
-	if (!grabMouseAndKeyboard()) {
+	if (m_isPrimary && !grabMouseAndKeyboard()) {
 		XUnmapWindow(m_display, m_window);
 		return false;
 	}


### PR DESCRIPTION
This solves the following issue I found:

1. Move mouse from PI server to Ubuntu client.
2. Move mouse back to PI server.
3. Try local mouse on Ubuntu client. Nothing happens.

Synergy Version: Latest synergy-core master as at 05/11/2018.
Client: Ubuntu 16.04
Server: Raspberry PI