### PR TITLE
Fixes Qt Headers for 5.11+ with the correct naming scheme

### DIFF
--- a/src/gui/src/ActionDialog.cpp
+++ b/src/gui/src/ActionDialog.cpp
@@ -25,8 +25,6 @@
 
 #include <QtCore>
 #include <QtGui>
-#include <qbuttongroup.h>
-
 #include <QButtonGroup>
 
 ActionDialog::ActionDialog(QWidget* parent, ServerConfig& config, Hotkey& hotkey, Action& action) :

--- a/src/gui/src/ScreenSetupView.cpp
+++ b/src/gui/src/ScreenSetupView.cpp
@@ -22,8 +22,6 @@
 
 #include <QtCore>
 #include <QtGui>
-#include <qheaderview.h>
-
 #include <QHeaderView>
 
 ScreenSetupView::ScreenSetupView(QWidget* parent) :


### PR DESCRIPTION
This fixes #6366 and #6375

Named the include correctly according to [review comments](https://github.com/symless/synergy-core/pull/6486#discussion_r279495680) (@darkdragon-001)