### PR TITLE
Pull in fixes from forks

### DIFF
--- a/dist/wix/Include.wxi.in
+++ b/dist/wix/Include.wxi.in
@@ -22,8 +22,4 @@
     <?define QtPlatformPath="$(var.QtPath)\plugins\platforms" ?>
     <?define OpenSSLPath="$(var.ExtPath)\openssl\windows\$(var.Platform)" ?>
     <?define OpenSSLBinPath="$(var.OpenSSLPath)\bin" ?>
-    <?if $(var.Configuration) = "Debug" ?>
-        <?define DebugCRT="$(env.CommonProgramFiles)\Merge Modules\Microsoft_VC140_DebugCRT_$(var.Platform).msm" ?>
-    <?endif ?>
-    <?define CRT="$(env.CommonProgramFiles)\Merge Modules\Microsoft_VC140_CRT_$(var.Platform).msm" ?>
 </Include>

--- a/dist/wix/Product.wxs
+++ b/dist/wix/Product.wxs
@@ -14,10 +14,6 @@
 			<ComponentGroupRef Id="ProductComponents"/>
 			<ComponentGroupRef Id="OpenSSLComponents"/>
 			<ComponentGroupRef Id="ProductQtPluginComponents"/>
-			<MergeRef Id="CRT"/>
-            <?if $(var.Configuration) = "Debug" ?>
-			    <MergeRef Id="DebugCRT"/>
-	        <?endif ?>
 			<ComponentRef Id="RegistryEntries"/>
 		</Feature>
 		<DirectoryRef Id="TARGETDIR">
@@ -73,10 +69,6 @@
 		<Directory Id="TARGETDIR" Name="SourceDir">
 			<Directory Id="$(var.ProgramFilesFolder)">
 				<Directory Id="INSTALLFOLDER" Name="$(var.Name)">
-					<Merge DiskId="1" Id="CRT" Language="0" SourceFile="$(var.CRT)"/>
-					<?if $(var.Configuration) = "Debug" ?>
-					    <Merge DiskId="1" Id="DebugCRT" Language="0" SourceFile="$(var.DebugCRT)"/>
-				    <?endif ?>
 					<Directory Id="OpenSSLDir" Name="OpenSSL"/>
 					<Directory Id="PlatformsDir" Name="Platforms"/>
 				</Directory>

--- a/src/cmd/synergyc/CMakeLists.txt
+++ b/src/cmd/synergyc/CMakeLists.txt
@@ -29,6 +29,7 @@ if (WIN32)
         tb_idle.ico
         tb_run.ico
         tb_wait.ico
+		synergyc.exe.manifest
     )
 elseif (APPLE)
     file(GLOB arch_headers "OSX*.h")

--- a/src/cmd/synergyc/synergyc.exe.manifest
+++ b/src/cmd/synergyc/synergyc.exe.manifest
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"></requestedExecutionLevel>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/cmd/synergys/CMakeLists.txt
+++ b/src/cmd/synergys/CMakeLists.txt
@@ -29,6 +29,7 @@ if (WIN32)
         tb_idle.ico
         tb_run.ico
         tb_wait.ico
+		synergys.exe.manifest
     )
 elseif (APPLE)
     file(GLOB arch_headers "OSX*.h")

--- a/src/cmd/synergys/synergys.exe.manifest
+++ b/src/cmd/synergys/synergys.exe.manifest
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"></requestedExecutionLevel>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/gui/src/AppConfig.cpp
+++ b/src/gui/src/AppConfig.cpp
@@ -57,7 +57,8 @@ AppConfig::AppConfig(QSettings* settings) :
     m_CryptoEnabled(false),
     m_AutoHide(false),
     m_LastExpiringWarningTime(0),
-    m_AutoConfigServer()
+    m_AutoConfigServer(),
+    m_MinimizeToTray(false)
 {
     Q_ASSERT(m_pSettings);
 
@@ -165,6 +166,7 @@ void AppConfig::loadSettings()
     m_lastVersion = settings().value("lastVersion", "Unknown").toString();
     m_LastExpiringWarningTime = settings().value("lastExpiringWarningTime", 0).toInt();
     m_ActivationHasRun = settings().value("activationHasRun", false).toBool();
+    m_MinimizeToTray = settings().value("minimizeToTray", false).toBool();
 }
 
 void AppConfig::saveSettings()
@@ -191,6 +193,7 @@ void AppConfig::saveSettings()
     settings().setValue("lastVersion", m_lastVersion);
     settings().setValue("lastExpiringWarningTime", m_LastExpiringWarningTime);
     settings().setValue("activationHasRun", m_ActivationHasRun);
+    settings().setValue("minimizeToTray", m_MinimizeToTray);
     settings().sync();
 }
 
@@ -298,3 +301,7 @@ bool AppConfig::getCryptoEnabled() const {
 void AppConfig::setAutoHide(bool b) { m_AutoHide = b; }
 
 bool AppConfig::getAutoHide() { return m_AutoHide; }
+
+void AppConfig::setMinimizeToTray(bool b) { m_MinimizeToTray = b; }
+
+bool AppConfig::getMinimizeToTray() { return m_MinimizeToTray; }

--- a/src/gui/src/AppConfig.h
+++ b/src/gui/src/AppConfig.h
@@ -110,6 +110,9 @@ class AppConfig: public QObject
 
         QString lastVersion() const;
 
+        void setMinimizeToTray(bool b);
+        bool getMinimizeToTray();
+
         void saveSettings();
         void setLastVersion(QString version);
 
@@ -150,6 +153,7 @@ protected:
         QString m_lastVersion;
         int m_LastExpiringWarningTime;
         bool m_ActivationHasRun;
+        bool m_MinimizeToTray;
 
         static const char m_SynergysName[];
         static const char m_SynergycName[];

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -207,7 +207,9 @@ void MainWindow::open()
 {
     createTrayIcon();
 
-    if (!autoHide()) {
+    if (appConfig().getAutoHide()) {
+        hide();
+    } else {
         showNormal();
     }
 
@@ -539,24 +541,12 @@ void MainWindow::checkFingerprint(const QString& line)
 
 void MainWindow::checkSecureSocket(const QString& line)
 {
-    // obviously not very secure, since this can be tricked by injecting something
-    // into the log. however, since we don't have IPC between core and GUI... patches welcome.
-    if (line.contains(tlsCheckString)) {
-        secureSocket(true);
-    }
+	// obviously not very secure, since this can be tricked by injecting something
+	// into the log. however, since we don't have IPC between core and GUI... patches welcome.
+	if (line.contains(tlsCheckString)) {
+		secureSocket(true);
+	}
 }
-
-bool MainWindow::autoHide()
-{
-    if ((appConfig().processMode() == Desktop) &&
-        appConfig().getAutoHide()) {
-        hide();
-        return true;
-    }
-
-    return false;
-}
-
 QString MainWindow::getTimeStamp()
 {
     QDateTime current = QDateTime::currentDateTime();

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -263,6 +263,7 @@ void MainWindow::createTrayIcon()
 
     m_pTrayIcon = new QSystemTrayIcon(this);
     m_pTrayIcon->setContextMenu(m_pTrayIconMenu);
+    m_pTrayIcon->setToolTip("Synergy");
 
     connect(m_pTrayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
             this, SLOT(trayActivated(QSystemTrayIcon::ActivationReason)));
@@ -359,7 +360,6 @@ void MainWindow::setIcon(qSynergyState state)
 
 void MainWindow::trayActivated(QSystemTrayIcon::ActivationReason reason)
 {
-#ifndef Q_OS_WIN
     if (reason == QSystemTrayIcon::DoubleClick)
     {
         if (isVisible())
@@ -372,7 +372,6 @@ void MainWindow::trayActivated(QSystemTrayIcon::ActivationReason reason)
             activateWindow();
         }
     }
-#endif
 }
 
 void MainWindow::logOutput()

--- a/src/gui/src/MainWindow.h
+++ b/src/gui/src/MainWindow.h
@@ -196,7 +196,6 @@ public slots:
 #ifndef SYNERGY_ENTERPRISE
         void checkLicense(const QString& line);
 #endif
-        bool autoHide();
         QString getTimeStamp();
         void restartSynergy();
         void proofreadInfo();

--- a/src/gui/src/MainWindow.h
+++ b/src/gui/src/MainWindow.h
@@ -176,7 +176,6 @@ public slots:
         bool serverArgs(QStringList& args, QString& app);
         void setStatus(const QString& status);
         void sendIpcMessage(qIpcMessageType type, const char* buffer, bool showErrors);
-        void onModeChanged(bool startDesktop, bool applyService);
         void updateFromLogLine(const QString& line);
         QString getIPAddresses();
         void stopService();
@@ -202,6 +201,9 @@ public slots:
 
         void showEvent (QShowEvent*);
         void secureSocket(bool secureSocket);
+
+        void windowStateChanged();
+
 
     private:
 #ifndef SYNERGY_ENTERPRISE

--- a/src/gui/src/MainWindowBase.ui
+++ b/src/gui/src/MainWindowBase.ui
@@ -18,8 +18,8 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>500</width>
-    <height>400</height>
+    <width>600</width>
+    <height>0</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/src/gui/src/SettingsDialog.cpp
+++ b/src/gui/src/SettingsDialog.cpp
@@ -57,6 +57,8 @@ SettingsDialog::SettingsDialog(QWidget* parent, AppConfig& config) :
     m_pLineEditLogFilename->setText(appConfig().logFilename());
     setIndexFromItemData(m_pComboLanguage, appConfig().language());
     m_pCheckBoxAutoHide->setChecked(appConfig().getAutoHide());
+    m_pCheckBoxMinimizeToTray->setChecked(appConfig().getMinimizeToTray());
+    m_pCheckBoxEnableCrypto->setChecked(m_appConfig.getCryptoEnabled());
 
 #if defined(Q_OS_WIN)
     m_pBonjourWindows = new BonjourWindows(this, m_pMainWindow, m_appConfig);
@@ -66,7 +68,6 @@ SettingsDialog::SettingsDialog(QWidget* parent, AppConfig& config) :
 
     m_pComboElevate->setCurrentIndex(static_cast<int>(appConfig().elevateMode()));
 
-    m_pCheckBoxAutoHide->hide();
 #else
     // elevate checkbox is only useful on ms windows.
     m_pLabelElevate->hide();
@@ -106,9 +107,10 @@ void SettingsDialog::accept()
     appConfig().setLogToFile(m_pCheckBoxLogToFile->isChecked());
     appConfig().setLogFilename(m_pLineEditLogFilename->text());
     appConfig().setLanguage(m_pComboLanguage->itemData(m_pComboLanguage->currentIndex()).toString());
-       appConfig().setElevateMode(static_cast<ElevateMode>(m_pComboElevate->currentIndex()));
+    appConfig().setElevateMode(static_cast<ElevateMode>(m_pComboElevate->currentIndex()));
     appConfig().setAutoHide(m_pCheckBoxAutoHide->isChecked());
     appConfig().setAutoConfig(m_pCheckBoxAutoConfig->isChecked());
+    appConfig().setMinimizeToTray(m_pCheckBoxMinimizeToTray->isChecked());
     appConfig().saveSettings();
     QDialog::accept();
 }

--- a/src/gui/src/SettingsDialogBase.ui
+++ b/src/gui/src/SettingsDialogBase.ui
@@ -114,13 +114,6 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="m_pComboLanguage"/>
       </item>
-      <item row="5" column="0">
-       <widget class="QCheckBox" name="m_pCheckBoxAutoHide">
-        <property name="text">
-         <string>&amp;Hide on startup</string>
-        </property>
-       </widget>
-      </item>
       <item row="4" column="1">
        <widget class="QComboBox" name="m_pComboElevate">
         <property name="toolTip">
@@ -150,6 +143,20 @@
        <widget class="QLabel" name="m_pLabelElevate">
         <property name="text">
          <string>Elevate</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QCheckBox" name="m_pCheckBoxAutoHide">
+        <property name="text">
+         <string>&amp;Hide on startup</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QCheckBox" name="m_pCheckBoxMinimizeToTray">
+        <property name="text">
+         <string>Minimize to System &amp;Tray</string>
         </property>
        </widget>
       </item>
@@ -392,6 +399,7 @@
   <tabstop>m_pLineEditScreenName</tabstop>
   <tabstop>m_pSpinBoxPort</tabstop>
   <tabstop>m_pLineEditInterface</tabstop>
+  <tabstop>m_pCheckBoxMinimizeToTray</tabstop>
   <tabstop>m_pComboElevate</tabstop>
   <tabstop>m_pCheckBoxAutoHide</tabstop>
   <tabstop>m_pComboLogLevel</tabstop>

--- a/src/lib/net/SecureListenSocket.cpp
+++ b/src/lib/net/SecureListenSocket.cpp
@@ -38,15 +38,6 @@ SecureListenSocket::SecureListenSocket(
 {
 }
 
-SecureListenSocket::~SecureListenSocket()
-{
-    SecureSocketSet::iterator it;
-    for (it = m_secureSocketSet.begin(); it != m_secureSocketSet.end(); it++) {
-        delete *it;
-    }
-    m_secureSocketSet.clear();
-}
-
 IDataSocket*
 SecureListenSocket::accept()
 {
@@ -74,8 +65,6 @@ SecureListenSocket::accept()
         }
 
         socket->secureAccept();
-
-        m_secureSocketSet.insert(socket);
 
         return dynamic_cast<IDataSocket*>(socket);
     }

--- a/src/lib/net/SecureListenSocket.h
+++ b/src/lib/net/SecureListenSocket.h
@@ -28,14 +28,9 @@ class SecureListenSocket : public TCPListenSocket{
 public:
     SecureListenSocket(IEventQueue* events,
         SocketMultiplexer* socketMultiplexer, IArchNetwork::EAddressFamily family);
-    ~SecureListenSocket();
+
 
     // IListenSocket overrides
     virtual IDataSocket*
                         accept();
-
-private:
-    typedef std::set<IDataSocket*> SecureSocketSet;
-
-    SecureSocketSet        m_secureSocketSet;
 };

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -869,5 +869,9 @@ SecureSocket::showSecureConnectInfo()
 void
 SecureSocket::handleTCPConnected(const Event& event, void*)
 {
+    if (getSocket() == nullptr) {
+        LOG((CLOG_DEBUG "disregarding stale connect event"));
+        return;
+    }
     secureConnect();
 }

--- a/src/lib/net/TCPSocket.cpp
+++ b/src/lib/net/TCPSocket.cpp
@@ -51,6 +51,8 @@ TCPSocket::TCPSocket(IEventQueue* events, SocketMultiplexer* socketMultiplexer, 
         throw XSocketCreate(e.what());
     }
 
+    LOG((CLOG_DEBUG "Opening new socket: %08X", m_socket));
+
     init();
 }
 
@@ -63,6 +65,8 @@ TCPSocket::TCPSocket(IEventQueue* events, SocketMultiplexer* socketMultiplexer, 
     m_socketMultiplexer(socketMultiplexer)
 {
     assert(m_socket != NULL);
+
+    LOG((CLOG_DEBUG "Opening new socket: %08X", m_socket));
 
     // socket starts in connected state
     init();
@@ -97,6 +101,8 @@ TCPSocket::bind(const NetworkAddress& addr)
 void
 TCPSocket::close()
 {
+    LOG((CLOG_DEBUG "Closing socket: %08X", m_socket));
+
     // remove ourself from the multiplexer
     setJob(NULL);
 

--- a/src/lib/platform/XWindowsUtil.cpp
+++ b/src/lib/platform/XWindowsUtil.cpp
@@ -1781,8 +1781,10 @@ XWindowsUtil::ErrorLock::ignoreHandler(Display*, XErrorEvent* e, void*)
 }
 
 void
-XWindowsUtil::ErrorLock::saveHandler(Display*, XErrorEvent* e, void* flag)
+XWindowsUtil::ErrorLock::saveHandler(Display* display, XErrorEvent* e, void* flag)
 {
-    LOG((CLOG_DEBUG1 "flagging X error: %d", e->error_code));
+    char errtxt[1024];
+    XGetErrorText(display, e->error_code, errtxt, 1023);
+    LOG((CLOG_DEBUG1 "flagging X error: %d - %.1023s", e->error_code, errtxt));
     *static_cast<bool*>(flag) = true;
 }

--- a/src/lib/server/ClientListener.h
+++ b/src/lib/server/ClientListener.h
@@ -31,6 +31,7 @@ class IListenSocket;
 class ISocketFactory;
 class Server;
 class IEventQueue;
+class IDataSocket;
 
 class ClientListener {
 public:
@@ -72,10 +73,12 @@ private:
     void                handleClientDisconnected(const Event&, void*);
 
     void                cleanupListenSocket();
+    void                cleanupClientSockets();
 
 private:
     typedef std::set<ClientProxyUnknown*> NewClients;
     typedef std::deque<ClientProxy*> WaitingClients;
+    typedef std::set<IDataSocket*> ClientSockets;
 
     IListenSocket*        m_listen;
     ISocketFactory*        m_socketFactory;
@@ -84,4 +87,5 @@ private:
     Server*                m_server;
     IEventQueue*        m_events;
     bool                m_useSecureNetwork;
+    ClientSockets      m_clientSockets;
 };


### PR DESCRIPTION
Thought I would spend some time pulling in a number of fixes and improvments from forks that arn't in synergy.

I started the PR so you can track the changes im making  over time and will ask for review when im finished.

Changes thus far
- ce8c65f - Fixed access violation in SSL sockets 
- 5af4b13 - Double clicking tray shows GUI, Tray also has tooltip 
- ccb0237 - Fixed Autohide 
- 9240cc1 - Implimented Minimize to tray 
-  b3298ad - Fixed race condition 
- eb02587 - Added CLOG_DEBUG for opening/closing TCPSocket objects and fixed assert() crash
- 84fcbea - Added dpiAwareness PerMonitor, and set min height to auto for diffrent scaling
- edfc7e9 - Added description to XWindows error handler message 
- 3023f9b - removed redistributable magic from installer