### PR TITLE
Always send clipboard data when changing screen

### DIFF
--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -276,7 +276,6 @@ Client::setClipboard(ClipboardID id, const IClipboard* clipboard)
 {
      m_screen->setClipboard(id, clipboard);
     m_ownClipboard[id]  = false;
-    m_sentClipboard[id] = false;
 }
 
 void
@@ -284,7 +283,6 @@ Client::grabClipboard(ClipboardID id)
 {
     m_screen->grabClipboard(id);
     m_ownClipboard[id]  = false;
-    m_sentClipboard[id] = false;
 }
 
 void
@@ -422,12 +420,7 @@ Client::sendClipboard(ClipboardID id)
 
 		// save new time
 		m_timeClipboard[id] = clipboard.getTime();
-        // save and send data if different or not yet sent
-        if (!m_sentClipboard[id] || data != m_dataClipboard[id]) {
-            m_sentClipboard[id] = true;
-            m_dataClipboard[id] = data;
-            m_server->onClipboardChanged(id, &clipboard);
-        }
+        m_server->onClipboardChanged(id, &clipboard);
     }
 }
 
@@ -615,7 +608,6 @@ Client::handleConnected(const Event&, void*)
     // reset clipboard state
     for (ClipboardID id = 0; id < kClipboardEnd; ++id) {
         m_ownClipboard[id]  = false;
-        m_sentClipboard[id] = false;
         m_timeClipboard[id] = 0;
     }
 }
@@ -687,7 +679,6 @@ Client::handleClipboardGrabbed(const Event& event, void*)
 
     // we now own the clipboard and it has not been sent to the server
     m_ownClipboard[info->m_id]  = true;
-    m_sentClipboard[info->m_id] = false;
     m_timeClipboard[info->m_id] = 0;
 
     // if we're not the active screen then send the clipboard now,

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -210,9 +210,7 @@ private:
     bool                m_suspended;
     bool                m_connectOnResume;
     bool                m_ownClipboard[kClipboardEnd];
-    bool                m_sentClipboard[kClipboardEnd];
     IClipboard::Time    m_timeClipboard[kClipboardEnd];
-    String              m_dataClipboard[kClipboardEnd];
     IEventQueue*        m_events;
     std::size_t         m_expectedFileSize;
     String              m_receivedFileData;

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -1562,16 +1562,10 @@ Server::onClipboardChanged(BaseClientProxy* sender,
 	// get data
 	sender->getClipboard(id, &clipboard.m_clipboard);
 
-	// ignore if data hasn't changed
 	String data = clipboard.m_clipboard.marshall();
 	if (data.size() > m_maximumClipboardSize * 1024) {
 		LOG((CLOG_NOTE "not updating clipboard because it's over the size limit (%i KB) configured by the server",
 			m_maximumClipboardSize));
-		return;
-	}
-
-	if (data == clipboard.m_clipboardData) {
-		LOG((CLOG_DEBUG "ignored screen \"%s\" update of clipboard %d (unchanged)", clipboard.m_clipboardOwner.c_str(), id));
 		return;
 	}
 


### PR DESCRIPTION
I have observed that the clipboard sharing between the server and clients become out of sync when a client disconnect from the server and during that time perform a copy-action.

If the server's clipboard has remained unchanged, while the client reconnect, the data it hold versus the client are different, the server wont push an update because the server's logic is that "I have already sent the data, so lets not do it again".

I don't know if this is a design decision, but the way I see it is that the server's clipboard is the primary clipboard and any client which is connected afterward should have it's clipboard.

The downside to this change is that the clipboard data is always sent when changing screen, causing higher network usage.