### PR TITLE
Increased SSL keysize and SHA algorithm #6561

### DIFF
--- a/src/gui/src/SslCertificate.cpp
+++ b/src/gui/src/SslCertificate.cpp
@@ -25,8 +25,8 @@
 
 
 
-static const char kCertificateKeyLength[] = "rsa:1024"; //RSA Bit length (e.g. 1024/2048/4096)
-static const char kCertificateHashAlgorithm[] = "-sha1"; //fingerprint hashing algorithm
+static const char kCertificateKeyLength[] = "rsa:2048"; //RSA Bit length (e.g. 1024/2048/4096)
+static const char kCertificateHashAlgorithm[] = "-sha256"; //fingerprint hashing algorithm
 static const char kCertificateLifetime[] = "365";
 static const char kCertificateSubjectInfo[] = "/CN=Synergy";
 static const char kCertificateFilename[] = "Synergy.pem";


### PR DESCRIPTION
Upped the default key size of synergy TLS connections across all platforms

This won't replace an existing certificate.

The old certificate must be deleted manually.