### PR TITLE
Open SSL fixes for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,12 +293,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
         ${OPENSSL_ROOT}/lib/libcrypto.lib
     )
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    #Try use 1.1 for the latest features. otherwise use the default
-    IF(EXISTS /usr/local/opt/openssl@1.1)
-        set (OPENSSL_ROOT /usr/local/opt/openssl@1.1)
-    else()
-        set (OPENSSL_ROOT /usr/local/opt/openssl)
-    endif()
+    set (OPENSSL_ROOT /usr/local/opt/openssl)
     include_directories (BEFORE SYSTEM ${OPENSSL_ROOT}/include)
     set (OPENSSL_LIBS
         ${OPENSSL_ROOT}/lib/libssl.a
@@ -325,7 +320,7 @@ macro (configure_files srcDir destDir)
         set (sourceFilePath ${srcDir}/${sourceFile})
         if (IS_DIRECTORY ${sourceFilePath})
             message (STATUS "Copying directory ${sourceFile}")
-            make_directory (${destDir/${sourceFile})
+            make_directory (${destDir}/${sourceFile})
         else()
             message (STATUS "Copying file ${sourceFile}")
             configure_file (${sourceFilePath} ${destDir}/${sourceFile} COPYONLY)

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -28,10 +28,10 @@
 #include <openssl/err.h>
 #include <cstring>
 #include <sstream>
+#include <iterator>
 #include <cstdlib>
 #include <memory>
 #include <fstream>
-#include <regex>
 
 //
 // SecureSocket

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -393,6 +393,9 @@ SecureSocket::initContext(bool server)
     SSL_METHOD* m = const_cast<SSL_METHOD*>(method);
     m_ssl->m_context = SSL_CTX_new(m);
 
+    //Prevent the usage of of all version prior to TLSv1.2 as they are known to be vulnerable
+    SSL_CTX_set_options(m_ssl->m_context, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1);
+
     if (m_ssl->m_context == NULL) {
         showError();
     }
@@ -848,7 +851,7 @@ SecureSocket::showSecureConnectInfo()
         SSL_CIPHER_description(cipher, msg, kMsgSize);
         LOG((CLOG_DEBUG "openssl cipher: %s", msg));
 
-        LOG((CLOG_INFO "network encryption protocol: %s", SSL_CIPHER_get_version(cipher)));
+        LOG((CLOG_INFO "network encryption protocol: %s", SSL_get_version(m_ssl->m_ssl)));
 
     }
     else {


### PR DESCRIPTION
The patch to get SSL working on Linux seems to break it for Mac, this fixes those errors, also updated the displayed protocol version as some versions of open SSL return "SSLv3/TLSv1" for any protocol above SSLv3. 

The protocol is obtained from the cipher description function rather than the version function.

