### PR TITLE
Reverting changes the the openSSL binary location

### DIFF
--- a/src/gui/src/SslCertificate.cpp
+++ b/src/gui/src/SslCertificate.cpp
@@ -34,8 +34,8 @@ static const char kSslDir[] = "SSL";
 static const char kUnixOpenSslCommand[] = "openssl";
 
 #if defined(Q_OS_WIN)
-static const char kWinOpenSslBinary[] = "openssl.exe";
-static const char kConfigFile[] = "synergy.conf";
+static const char kWinOpenSslBinary[] = "OpenSSL\\openssl.exe";
+static const char kConfigFile[] = "OpenSSL\\synergy.conf";
 #endif
 
 SslCertificate::SslCertificate(QObject *parent) :


### PR DESCRIPTION
This reverts commit 1bc2cf57

Fixes #6608 