### PR TITLE
Fixed quote key on US International keyboard

### DIFF
--- a/src/lib/synergy/KeyMap.cpp
+++ b/src/lib/synergy/KeyMap.cpp
@@ -1104,6 +1104,7 @@ KeyMap::getDeadKey(KeyID key)
     case '`':
         return kKeyDeadGrave;
 
+    case '\'':
     case 0xb4u:
         return kKeyDeadAcute;
 


### PR DESCRIPTION
Original PR #6448 

Fixes #4 

Fixes quote key on US international keyboards

New PR created as old PR would pull in v2 changes 