### PR TITLE
Fixed multi-layout keyboard bugs on macOS client

### DIFF
--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -397,15 +397,15 @@ OSXKeyState::pollActiveModifiers() const
 SInt32
 OSXKeyState::pollActiveGroup() const
 {
-    bool layoutValid = true;
     TISInputSourceRef keyboardLayout = TISCopyCurrentKeyboardLayoutInputSource();
-    
-    if (layoutValid) {
-        GroupMap::const_iterator i = m_groupMap.find(keyboardLayout);
-        if (i != m_groupMap.end()) {
-            return i->second;
-        }
+
+    GroupMap::const_iterator i = m_groupMap.find(keyboardLayout);
+    if (i != m_groupMap.end()) {
+        return i->second;
     }
+
+    LOG((CLOG_DEBUG "can't get the active group, use the first group instead"));
+
     return 0;
 }
 

--- a/src/lib/platform/OSXKeyState.h
+++ b/src/lib/platform/OSXKeyState.h
@@ -165,7 +165,8 @@ private:
         KeyButtonOffset = 1
     };
 
-    typedef std::map<CFDataRef, SInt32> GroupMap;
+    typedef std::map<KeyLayout, SInt32> GroupMap;
+    // typedef std::map<CFDataRef, SInt32> GroupMap;
     typedef std::map<UInt32, KeyID> VirtualKeyMap;
 
     VirtualKeyMap        m_virtualKeyMap;

--- a/src/lib/platform/OSXKeyState.h
+++ b/src/lib/platform/OSXKeyState.h
@@ -166,7 +166,6 @@ private:
     };
 
     typedef std::map<KeyLayout, SInt32> GroupMap;
-    // typedef std::map<CFDataRef, SInt32> GroupMap;
     typedef std::map<UInt32, KeyID> VirtualKeyMap;
 
     VirtualKeyMap        m_virtualKeyMap;


### PR DESCRIPTION
Original PR #6433 by @inlife
> when using multiple layout on a macos client machine, the switching to other than default layout causes input bugs, where some of the keys are still on the default layout and some are on switched one
>
>this fix makes sure that layout will be properly switched

Cherry-pick also removed some whitespace from the files.