### PR TITLE
Added context menu link to the help site

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -17,6 +17,7 @@
  */
 
 #define DOWNLOAD_URL "http://symless.com/?source=gui"
+#define HELP_URL     "http://symless.com/help?source=gui"
 
 #include <iostream>
 
@@ -290,6 +291,8 @@ void MainWindow::createMenuBar()
     m_pMenuWindow->addAction(m_pActionMinimize);
     m_pMenuWindow->addAction(m_pActionRestore);
     m_pMenuHelp->addAction(m_pActionAbout);
+    m_pMenuHelp->addAction(m_pActionHelp);
+
 
     setMenuBar(m_pMenuBar);
 }
@@ -1226,6 +1229,11 @@ void MainWindow::on_m_pActionAbout_triggered()
 {
     AboutDialog dlg(this, appPath(appConfig().synergycName()));
     dlg.exec();
+}
+
+void MainWindow::on_m_pActionHelp_triggered()
+{
+    QDesktopServices::openUrl(QUrl(HELP_URL));
 }
 
 void MainWindow::updateZeroconfService()

--- a/src/gui/src/MainWindow.h
+++ b/src/gui/src/MainWindow.h
@@ -149,6 +149,7 @@ public slots:
         void on_m_pButtonConfigureServer_clicked();
         bool on_m_pActionSave_triggered();
         void on_m_pActionAbout_triggered();
+        void on_m_pActionHelp_triggered();
         void on_m_pActionSettings_triggered();
         void on_m_pActivate_triggered();
         void synergyFinished(int exitCode, QProcess::ExitStatus);

--- a/src/gui/src/MainWindowBase.ui
+++ b/src/gui/src/MainWindowBase.ui
@@ -535,6 +535,14 @@
     <string notr="true"/>
    </property>
   </action>
+  <action name="m_pActionHelp">
+   <property name="text">
+    <string>Visit &amp;help site</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
+  </action>
   <action name="m_pActionQuit">
    <property name="text">
     <string>&amp;Quit</string>


### PR DESCRIPTION
Fixes #6472 
This adds a help entry linking to [symless website help page]("http://symless.com/help?source=gui").

* creates new "Help" sub-menu in OS X
* nests under existing "Help" sub-menu for all other platforms.