### PR TITLE
Added signal when auto config is changed to update UI

### DIFF
--- a/src/gui/src/AppConfig.cpp
+++ b/src/gui/src/AppConfig.cpp
@@ -244,6 +244,7 @@ void AppConfig::setElevateMode(ElevateMode em) { m_ElevateMode = em; }
 void AppConfig::setAutoConfig(bool autoConfig)
 {
     m_AutoConfig = autoConfig;
+    emit zeroConfToggled();
 }
 
 void AppConfig::setAutoConfigServer(QString autoConfigServer)

--- a/src/gui/src/AppConfig.h
+++ b/src/gui/src/AppConfig.h
@@ -161,6 +161,7 @@ protected:
 
     signals:
         void sslToggled(bool enabled);
+        void zeroConfToggled();
 };
 
 #endif

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -181,6 +181,9 @@ MainWindow::MainWindow (QSettings& settings, AppConfig& appConfig,
     connect (m_AppConfig, SIGNAL(sslToggled(bool)),
              this, SLOT(sslToggled(bool)), Qt::QueuedConnection);
 
+    connect (m_AppConfig, SIGNAL(zeroConfToggled()),
+             this, SLOT(zeroConfToggled()), Qt::QueuedConnection);
+
 #ifdef SYNERGY_ENTERPRISE
     setWindowTitle ("Synergy 1 Enterprise");
 #else
@@ -355,6 +358,15 @@ void MainWindow::saveSettings()
     settings().sync();
 }
 
+void MainWindow::zeroConfToggled() {
+#ifndef SYNERGY_ENTERPRISE
+    updateZeroconfService();
+
+    addZeroconfServer(m_AppConfig->autoConfigServer());
+
+    updateAutoConfigWidgets();
+#endif
+}
 void MainWindow::setIcon(qSynergyState state)
 {
     QIcon icon;

--- a/src/gui/src/MainWindow.h
+++ b/src/gui/src/MainWindow.h
@@ -160,6 +160,9 @@ public slots:
         void updateFound(const QString& version);
         void saveSettings();
 
+        /// @brief Receives the signal that the auto config option has changed
+        void zeroConfToggled();
+
     protected:
         QSettings& settings() { return m_Settings; }
         AppConfig& appConfig() { return *m_AppConfig; }


### PR DESCRIPTION
Fixes #6587 

When the auto configure option is changed a signal is sent to the main window to update and start the service