### PR TITLE
Cursor freezes intermittently on Linux

### DIFF
--- a/src/lib/platform/XWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/XWindowsEventQueueBuffer.cpp
@@ -162,31 +162,31 @@ XWindowsEventQueueBuffer::waitForEvent(double dtimeout)
     // we want to give the cpu a chance s owe up this to 25ms
 #define TIMEOUT_DELAY 25
 
-    while (((dtimeout < 0.0) || (remaining > 0)) && QLength(m_display)==0 && retval==0){
+//    while (((dtimeout < 0.0) || (remaining > 0)) && QLength(m_display)==0 && retval==0){
 #if HAVE_POLL
-    retval = poll(pfds, 2, TIMEOUT_DELAY); //16ms = 60hz, but we make it > to play nicely with the cpu
-     if (pfds[1].revents & POLLIN) {
-         ssize_t read_response = read(m_pipefd[0], buf, 15);
-        
-        // with linux automake, warnings are treated as errors by default
-        if (read_response < 0)
-        {
-            // todo: handle read response
-        }
-
-     }
+//    retval = poll(pfds, 2, TIMEOUT_DELAY); //16ms = 60hz, but we make it > to play nicely with the cpu
+//     if (pfds[1].revents & POLLIN) {
+//         ssize_t read_response = read(m_pipefd[0], buf, 15);
+//
+//        // with linux automake, warnings are treated as errors by default
+//        if (read_response < 0)
+//        {
+//            // todo: handle read response
+//        }
+//
+//     }
 #else
-    retval = select(nfds,
-                        SELECT_TYPE_ARG234 &rfds,
-                        SELECT_TYPE_ARG234 NULL,
-                        SELECT_TYPE_ARG234 NULL,
-                        SELECT_TYPE_ARG5   TIMEOUT_DELAY);
-    if (FD_SET(m_pipefd[0], &rfds)) {
-        read(m_pipefd[0], buf, 15);
-    }
+//    retval = select(nfds,
+//                        SELECT_TYPE_ARG234 &rfds,
+//                        SELECT_TYPE_ARG234 NULL,
+//                        SELECT_TYPE_ARG234 NULL,
+//                        SELECT_TYPE_ARG5   TIMEOUT_DELAY);
+//    if (FD_SET(m_pipefd[0], &rfds)) {
+//        read(m_pipefd[0], buf, 15);
+//    }
 #endif
-        remaining-=TIMEOUT_DELAY;
-    }
+//        remaining-=TIMEOUT_DELAY;
+//    }
 
     {
         // we're no longer waiting for events

--- a/src/lib/platform/XWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/XWindowsEventQueueBuffer.cpp
@@ -162,31 +162,31 @@ XWindowsEventQueueBuffer::waitForEvent(double dtimeout)
     // we want to give the cpu a chance s owe up this to 25ms
 #define TIMEOUT_DELAY 25
 
-//    while (((dtimeout < 0.0) || (remaining > 0)) && QLength(m_display)==0 && retval==0){
+    while (((dtimeout < 0.0) || (remaining > 0)) && QLength(m_display)==0 && retval==0){
 #if HAVE_POLL
-//    retval = poll(pfds, 2, TIMEOUT_DELAY); //16ms = 60hz, but we make it > to play nicely with the cpu
-//     if (pfds[1].revents & POLLIN) {
-//         ssize_t read_response = read(m_pipefd[0], buf, 15);
-//
-//        // with linux automake, warnings are treated as errors by default
-//        if (read_response < 0)
-//        {
-//            // todo: handle read response
-//        }
-//
-//     }
+    retval = poll(pfds, 2, TIMEOUT_DELAY); //16ms = 60hz, but we make it > to play nicely with the cpu
+     if (pfds[1].revents & POLLIN) {
+         ssize_t read_response = read(m_pipefd[0], buf, 15);
+        
+        // with linux automake, warnings are treated as errors by default
+        if (read_response < 0)
+        {
+            // todo: handle read response
+        }
+
+     }
 #else
-//    retval = select(nfds,
-//                        SELECT_TYPE_ARG234 &rfds,
-//                        SELECT_TYPE_ARG234 NULL,
-//                        SELECT_TYPE_ARG234 NULL,
-//                        SELECT_TYPE_ARG5   TIMEOUT_DELAY);
-//    if (FD_SET(m_pipefd[0], &rfds)) {
-//        read(m_pipefd[0], buf, 15);
-//    }
+    retval = select(nfds,
+                        SELECT_TYPE_ARG234 &rfds,
+                        SELECT_TYPE_ARG234 NULL,
+                        SELECT_TYPE_ARG234 NULL,
+                        SELECT_TYPE_ARG5   TIMEOUT_DELAY);
+    if (FD_SET(m_pipefd[0], &rfds)) {
+        read(m_pipefd[0], buf, 15);
+    }
 #endif
-//        remaining-=TIMEOUT_DELAY;
-//    }
+        remaining-=TIMEOUT_DELAY;
+    }
 
     {
         // we're no longer waiting for events

--- a/src/lib/platform/XWindowsEventQueueBuffer.cpp
+++ b/src/lib/platform/XWindowsEventQueueBuffer.cpp
@@ -120,7 +120,7 @@ XWindowsEventQueueBuffer::waitForEvent(double dtimeout)
     pfds[1].fd     = m_pipefd[0];
     pfds[1].events = POLLIN;
     int timeout    = (dtimeout < 0.0) ? -1 :
-                        static_cast<int>(1000.0 * dtimeout);
+                        static_cast<int>(dtimeout);
     int remaining  =  timeout;
     int retval     =  0;
 #else


### PR DESCRIPTION
Fixes #6487 

A fix in the xlib package's poll function fixed a bug where even if there where no events in the queue instead of waiting for the time out delay before returning, the function would instead return immediately. Synergy handled this by increasing the number of times the the loop would poll by a factor of 1000. 

So the 15ms delay was instead 15 seconds. An event normally broke the loop well before the 15 seconds was up but this cause noticeable freezes in the cursor as the thread was essentially locked up in that loop.

This PR removes the 1000x multiplayer reducing the loop down and solves the freezing issue.