### PR TITLE
Changed user scope setting location back

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+v1.12.0-rc2
+===========
+
+Bug fixes:
+- #6730 Updating synergy looses settings
+
 v1.12.0-rc1
 ===========
 

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -7,7 +7,7 @@ cmake_minimum_required (VERSION 3.4)
 set (SYNERGY_VERSION_MAJOR 1)
 set (SYNERGY_VERSION_MINOR 12)
 set (SYNERGY_VERSION_PATCH 0)
-set (SYNERGY_VERSION_STAGE "rc1")
+set (SYNERGY_VERSION_STAGE "snapshot")
 
 #
 # Version from CI

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -7,7 +7,7 @@ cmake_minimum_required (VERSION 3.4)
 set (SYNERGY_VERSION_MAJOR 1)
 set (SYNERGY_VERSION_MINOR 12)
 set (SYNERGY_VERSION_PATCH 0)
-set (SYNERGY_VERSION_STAGE "snapshot")
+set (SYNERGY_VERSION_STAGE "rc1")
 
 #
 # Version from CI

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -7,7 +7,7 @@ cmake_minimum_required (VERSION 3.4)
 set (SYNERGY_VERSION_MAJOR 1)
 set (SYNERGY_VERSION_MINOR 12)
 set (SYNERGY_VERSION_PATCH 0)
-set (SYNERGY_VERSION_STAGE "rc1")
+set (SYNERGY_VERSION_STAGE "rc2")
 
 #
 # Version from CI

--- a/src/gui/src/ConfigWriter.cpp
+++ b/src/gui/src/ConfigWriter.cpp
@@ -51,9 +51,10 @@ namespace GUI {
                                              QCoreApplication::organizationName(),
                                              QCoreApplication::applicationName());
 
-            m_pSettingsUser = new QSettings(QSettings::Scope::UserScope,
-                                   QCoreApplication::organizationName(),
-                                   QCoreApplication::applicationName());
+            //defaults to user scope, if we set the scope specifically then we also have to set
+            // the application name and the organisation name which breaks backwards compatibility
+            // See #6730
+            m_pSettingsUser = new QSettings();
 
             //Set scope to user for initially
             m_pSettingsCurrent = m_pSettingsUser;


### PR DESCRIPTION
Adding the system scoped settings changed the location of the user scoped setting which broke backward compatibility with older settings, This PR intends to solve that issue

Resolves #6730 