### PR TITLE
Fixed naming of installers for linux and windows

### DIFF
--- a/CI/Linux/linux-build.yml
+++ b/CI/Linux/linux-build.yml
@@ -15,7 +15,6 @@ steps:
       else cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:PATH=$(pwd)/rpm/BUILDROOT/usr ..;
       fi
       make -j
-      make install/strip
     condition: eq(variables['packager'],'rpm')
     displayName: 'Build Release rpm'
 
@@ -36,7 +35,6 @@ steps:
       else cmake -DCMAKE_BUILD_TYPE=Release -DSYNERGY_ENTERPRISE=ON -DCMAKE_INSTALL_PREFIX:PATH=$(pwd)/rpm/BUILDROOT/usr ..;
       fi
       make -j
-      make install/strip
     condition: eq(variables['packager'],'rpm')
     displayName: 'Build enterprise rpm'
 
@@ -65,9 +63,9 @@ steps:
       filename_new="synergy_${SYNERGY_DEB_VERSION}_$(name)${filename##*${SYNERGY_REVISION}}"
       mv $filename $(Build.Repository.LocalPath)/standard_package/$filename_new
       cd $(Build.Repository.LocalPath)/standard_package
-      md5sum $filename_new >> ${filename_new}.md5
-      sha1sum $filename_new >> ${filename_new}.sha1
-      sha256sum $filename_new >> ${filename_new}.sha256
+      md5sum $filename_new >> ${filename_new}.checksum.txt
+      sha1sum $filename_new >> ${filename_new}.checksum.txt
+      sha256sum $filename_new >> ${filename_new}.checksum.txt
       ls -la
     displayName: "Package Binary DEB(Standard)"
     condition: and(eq(variables['packager'],'deb'), eq(variables['Build.Reason'], 'Manual'))
@@ -84,36 +82,40 @@ steps:
       filename_new="synergy-enterprise_$(SYNERGY_DEB_VERSION)_$(name)${filename##*$(SYNERGY_REVISION)}"
       mv $filename $(Build.Repository.LocalPath)/enterprise_package/$filename_new
       cd $(Build.Repository.LocalPath)/enterprise_package
-      md5sum $filename_new >> ${filename_new}.md5
-      sha1sum $filename_new >> ${filename_new}.sha1
-      sha256sum $filename_new >> ${filename_new}.sha256
+      md5sum $filename_new >> ${filename_new}.checksum.txt
+      sha1sum $filename_new >> ${filename_new}.checksum.txt
+      sha256sum $filename_new >> ${filename_new}.checksum.txt
       ls -la
     displayName: "Package Binary DEB(Enterprise)"
     condition: and(eq(variables['packager'],'deb'), eq(variables['Build.Reason'], 'Manual'))
 
   - script: |
-      cd build-release/rpm
+      cd build-release
+      make install/strip
+      cd rpm
       rpmbuild -bb --define "_topdir $(pwd)" --buildroot $(pwd)/BUILDROOT synergy.spec
       rpmlint --verbose RPMS/x86_64/*.rpm
       cd RPMS/x86_64
       filename=$(ls *.rpm)
-      md5sum $filename >> ${filename}.md5
-      sha1sum $filename >> ${filename}.sha1
-      sha256sum $filename >> ${filename}.sha256
+      md5sum $filename >> ${filename}.checksum.txt
+      sha1sum $filename >> ${filename}.checksum.txt
+      sha256sum $filename >> ${filename}.checksum.txt
       cd ..
       mv x86_64 $(Build.Repository.LocalPath)/standard_package
     displayName: "Package Binary RPM(standard)"
     condition: and(eq(variables['packager'],'rpm'), eq(variables['Build.Reason'], 'Manual'))
 
   - script: |
-      cd build-ent/rpm
+      cd build-release
+      make install/strip
+      cd rpm
       rpmbuild -bb --define "_topdir $(pwd)" --buildroot $(pwd)/BUILDROOT synergy.spec
       rpmlint --verbose RPMS/x86_64/*.rpm
       cd RPMS/x86_64
       filename=$(ls *.rpm)
-      md5sum $filename >> ${filename}.md5
-      sha1sum $filename >> ${filename}.sha1
-      sha256sum $filename >> ${filename}.sha256
+      md5sum $filename >> ${filename}.checksum.txt
+      sha1sum $filename >> ${filename}.checksum.txt
+      sha256sum $filename >> ${filename}.checksum.txt
       cd ..
       mv x86_64 $(Build.Repository.LocalPath)/enterprise_package
       ls -la

--- a/CI/Linux/linux-build.yml
+++ b/CI/Linux/linux-build.yml
@@ -6,6 +6,8 @@ steps:
       make -j
     condition: eq(variables['packager'],'deb')
     displayName: 'Build Release deb'
+    env:
+      GIT_COMMIT: $(Build.SourceVersion)
 
   - script: |
       mkdir build-release
@@ -17,6 +19,8 @@ steps:
       make -j
     condition: eq(variables['packager'],'rpm')
     displayName: 'Build Release rpm'
+    env:
+      GIT_COMMIT: $(Build.SourceVersion)
 
   - script: |
       mkdir build-ent
@@ -26,6 +30,8 @@ steps:
       make -j
     displayName: 'Build enterprise'
     condition: eq(variables['packager'],'deb')
+    env:
+      GIT_COMMIT: $(Build.SourceVersion)
 
   - script: |
       mkdir build-ent
@@ -37,6 +43,8 @@ steps:
       make -j
     condition: eq(variables['packager'],'rpm')
     displayName: 'Build enterprise rpm'
+    env:
+      GIT_COMMIT: $(Build.SourceVersion)
 
   - script: |
       . ./build-release/version

--- a/CI/MacOS/mac-build.yml
+++ b/CI/MacOS/mac-build.yml
@@ -81,9 +81,9 @@ steps:
         mkdir pkg
         mv $(SYNERGY_DMG_FILENAME) pkg/
         cd pkg
-        md5 -r $(SYNERGY_DMG_FILENAME) >> $(SYNERGY_DMG_FILENAME).md5
-        shasum $(SYNERGY_DMG_FILENAME) >> $(SYNERGY_DMG_FILENAME).sha1
-        shasum -a 256 $(SYNERGY_DMG_FILENAME) >> $(SYNERGY_DMG_FILENAME).sha256
+        md5 -r $(SYNERGY_DMG_FILENAME) >> $(SYNERGY_DMG_FILENAME).checksum.txt
+        shasum $(SYNERGY_DMG_FILENAME) >> $(SYNERGY_DMG_FILENAME).checksum.txt
+        shasum -a 256 $(SYNERGY_DMG_FILENAME) >> $(SYNERGY_DMG_FILENAME).checksum.txt
     displayName: 'Create Installer'
     condition: eq(variables['Build.Reason'], 'Manual')
 

--- a/CI/Windows/windows-build.yml
+++ b/CI/Windows/windows-build.yml
@@ -172,13 +172,13 @@ steps:
 
   - script: |
       cd $(Build.Repository.LocalPath)\build32\installer\bin\Release\
-      set FILENAME=$(prefix)_v$(SYNERGY_VERSION)-$(SYNERGY_VERSION_STAGE)_$(Build.BuildNumber).$(SYNERGY_VERSION_STAGE)_windows_x86.msi
+      set FILENAME=$(prefix)_v$(SYNERGY_VERSION)-$(SYNERGY_VERSION_STAGE)_$(Build.BuildNumber).$(SYNERGY_REVISION)_windows_x86.msi
       ren "Synergy.msi" "%FILENAME%"
       $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe md5 %FILENAME% > %FILENAME%.checksum.txt
       $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe sha1 %FILENAME% >> %FILENAME%.checksum.txt
       $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe sha256 %FILENAME% >> %FILENAME%.checksum.txt
       cd $(Build.Repository.LocalPath)\build64\installer\bin\Release\
-      set FILENAME=$(prefix)_v$(SYNERGY_VERSION)-$(SYNERGY_VERSION_STAGE)_$(Build.BuildNumber).$(SYNERGY_VERSION_STAGE)_windows_x64.msi
+      set FILENAME=$(prefix)_v$(SYNERGY_VERSION)-$(SYNERGY_VERSION_STAGE)_$(Build.BuildNumber).$(SYNERGY_REVISION)_windows_x64.msi
       ren "Synergy.msi" "%FILENAME%"
       $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe md5 %FILENAME% > %FILENAME%.checksum.txt
       $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe sha1 %FILENAME% >> %FILENAME%.checksum.txt

--- a/CI/Windows/windows-build.yml
+++ b/CI/Windows/windows-build.yml
@@ -142,7 +142,7 @@ steps:
       rootFolderOrFile: 'build32\bin\Release'
       includeRootFolder: false
       archiveType: 'zip'
-      archiveFile: '$(Build.ArtifactStagingDirectory)/Synergy_x86.zip'
+      archiveFile: '$(Build.ArtifactStagingDirectory)/Synergy_win_x86.zip'
       replaceExistingArchive: true
       verbose: true
     displayName: "Archive 32-bit binaries"
@@ -153,7 +153,7 @@ steps:
       rootFolderOrFile: 'build64\bin\Release'
       includeRootFolder: false
       archiveType: 'zip'
-      archiveFile: '$(Build.ArtifactStagingDirectory)/Synergy_x64.zip'
+      archiveFile: '$(Build.ArtifactStagingDirectory)/Synergy_win_x64.zip'
       replaceExistingArchive: true
       verbose: true
     displayName: "Archive 64-bit binaries"
@@ -167,18 +167,22 @@ steps:
       echo ##vso[task.setvariable variable=SYNERGY_VERSION_STAGE]%SYNERGY_VERSION_STAGE%
       echo ##vso[task.setvariable variable=SYNERGY_VERSION]%SYNERGY_VERSION%
       echo ##vso[task.setvariable variable=SYNERGY_REVISION]%SYNERGY_REVISION%
+    displayName: "Set Variables"
+    condition: or(eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+
+  - script: |
       cd $(Build.Repository.LocalPath)\build32\installer\bin\Release\
-      set FILENAME=$(prefix)_v%SYNERGY_VERSION%_windows_x86.msi
+      set FILENAME=$(prefix)_v$(SYNERGY_VERSION)-$(SYNERGY_VERSION_STAGE)_$(Build.BuildNumber).$(SYNERGY_VERSION_STAGE)_windows_x86.msi
       ren "Synergy.msi" "%FILENAME%"
-      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe md5 %FILENAME% > %FILENAME%.md5
-      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe sha1 %FILENAME% > %FILENAME%.sha1
-      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe sha256 %FILENAME% > %FILENAME%.sha256
+      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe md5 %FILENAME% > %FILENAME%.checksum.txt
+      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe sha1 %FILENAME% >> %FILENAME%.checksum.txt
+      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe sha256 %FILENAME% >> %FILENAME%.checksum.txt
       cd $(Build.Repository.LocalPath)\build64\installer\bin\Release\
-      set FILENAME=$(prefix)_v%SYNERGY_VERSION%_windows_x64.msi
+      set FILENAME=$(prefix)_v$(SYNERGY_VERSION)-$(SYNERGY_VERSION_STAGE)_$(Build.BuildNumber).$(SYNERGY_VERSION_STAGE)_windows_x64.msi
       ren "Synergy.msi" "%FILENAME%"
-      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe md5 %FILENAME% > %FILENAME%.md5
-      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe sha1 %FILENAME% > %FILENAME%.sha1
-      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe sha256 %FILENAME% > %FILENAME%.sha256
+      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe md5 %FILENAME% > %FILENAME%.checksum.txt
+      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe sha1 %FILENAME% >> %FILENAME%.checksum.txt
+      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe sha256 %FILENAME% >> %FILENAME%.checksum.txt
     displayName: "Rename files"
     condition: eq(variables['Build.Reason'], 'Manual')
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ v1.12.0-rc2
 
 Bug fixes:
 - #6730 Updating synergy looses settings
+- #6734 Fixed naming of installers for linux and windows
 
 v1.12.0-rc1
 ===========


### PR DESCRIPTION
Resolves #6734 

This PR correctly name the installer file for both Windows and Linux, This also combines all the checksums into a single txt file for each installer