### PR TITLE
Fixed  account name with spaces causing TLS path errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ v1.12.x-snapshot
 ===========
 Bug fixes:
 - #6753 Fixed a number of vulnerabilities detected by static analysis
+- #6758 Account name with space on windows causes synergy to error when starting
 
 Enhancements:
 - #6750 Integrate SonarCloud for static analysis and test coverage

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -670,7 +670,7 @@ void MainWindow::startSynergy()
 
     if (m_AppConfig->getCryptoEnabled()) {
         args << "--enable-crypto";
-        args << "--tls-cert" << m_AppConfig->getTLSCertPath();
+        args << "--tls-cert" <<  QString("\"%1\"").arg(m_AppConfig->getTLSCertPath());
     }
 
 #if defined(Q_OS_WIN)


### PR DESCRIPTION
Resolves #6758