### PR TITLE
SYNERGY-292 Added Ubuntu 16 back the the build pipline

### DIFF
--- a/CI/Linux/linux-build.yml
+++ b/CI/Linux/linux-build.yml
@@ -66,7 +66,6 @@ steps:
 
   - script: |
       dch --create --package "synergy" --controlmaint --distribution unstable --newversion $SYNERGY_DEB_VERSION "Initial release"
-      export DEB_BUILD_OPTIONS="parallel=8"
       export GPG_TTY=$(tty)
       debuild --preserve-envvar SYNERGY_* --preserve-envvar GIT_COMMIT -us -uc
       mkdir standard_package
@@ -87,7 +86,6 @@ steps:
   - script: |
       export SYNERGY_ENTERPRISE=1
       dch --create --package "synergy-enterprise_" --controlmaint --distribution unstable --newversion $(SYNERGY_DEB_VERSION) "Initial release"
-      export DEB_BUILD_OPTIONS="parallel=8"
       export GPG_TTY=$(tty)
       debuild --preserve-envvar SYNERGY_* --preserve-envvar GIT_COMMIT -us -uc
       mkdir enterprise_package

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ Bug fixes:
 - #6758 Account name with space on windows causes synergy to error when starting
 - #6760 Synergy loses license when creating a System scope config
 - #6342 Updated copyright year in version to use build date
+- #6771 Added Ubuntu 16 to CI/CD
 
 Enhancements:
 - #6750 Integrate SonarCloud for static analysis and test coverage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,10 @@ jobs:
 
     strategy:
       matrix:
+        ubuntu1604:
+          image: symless/synergy-core:ubuntu16.04
+          packager: deb
+          name: ubuntu16
         ubuntu1804:
           image: symless/synergy-core:ubuntu18.04
           packager: deb


### PR DESCRIPTION
Resolves #6771 

For some reason Ubuntu 16 didn't like running in parallel and as azure doesn't give
many cores. Disabling multi core building doesn't affect the time that much