### PR TITLE
Add missing XAtom for utf-8 handling with Xorg.

### DIFF
--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -83,6 +83,8 @@ XWindowsClipboard::XWindowsClipboard(Display* display,
     m_converters.push_back(new XWindowsClipboardUTF8Converter(m_display,
                                 "text/plain;charset=UTF-8"));
     m_converters.push_back(new XWindowsClipboardUTF8Converter(m_display,
+                                "text/plain;charset=utf-8"));
+    m_converters.push_back(new XWindowsClipboardUTF8Converter(m_display,
                                 "UTF8_STRING"));
     m_converters.push_back(new XWindowsClipboardUCS2Converter(m_display,
                                 "text/plain;charset=ISO-10646-UCS-2"));


### PR DESCRIPTION
Resolves #6660 
Resolves #6582 

Added atom "text/plain;charset=utf-8" to the m_converters list to prevent falling back to "STRING", causing non ASCII characters to be replaced by question marks. Note that the capital UTF-8 atom is also a valid one.