### PR TITLE
SYNERGY-362 Eliminate using std::chrono 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,7 +22,7 @@ Enhancements:
 - #6803 Update Synergy icons
 - #6800 Update behaviour when unregistered
 - #6806 Move to Github Action for general PR builds and tests
-- #6816 Improve license validation
+- #6816 Improve license key validation
 
 v1.12.0-stable
 ===========

--- a/src/lib/shared/SerialKey.cpp
+++ b/src/lib/shared/SerialKey.cpp
@@ -180,7 +180,7 @@ SerialKey::getSpanLeft(time_t time) const
         auto timeLeft = (m_expireTime - time) * 1000;
 
         if (timeLeft < INT_MAX){
-            result = timeLeft;
+            result = static_cast<int>(timeLeft);
         }
         else{
             result = INT_MAX;

--- a/src/lib/shared/SerialKey.cpp
+++ b/src/lib/shared/SerialKey.cpp
@@ -25,7 +25,6 @@
 #include <sstream>
 #include <iomanip>
 #include <stdexcept>
-#include <chrono>
 #include "SerialKeyEdition.h"
 
 using namespace std;

--- a/src/lib/shared/SerialKey.cpp
+++ b/src/lib/shared/SerialKey.cpp
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <iomanip>
 #include <stdexcept>
+#include <chrono>
 #include "SerialKeyEdition.h"
 
 using namespace std;
@@ -171,18 +172,23 @@ SerialKey::daysLeft(time_t currentTime) const
     return timeLeft / day + daysLeft;
 }
 
-std::chrono::milliseconds
+int
 SerialKey::getSpanLeft(time_t time) const
 {
-    std::chrono::milliseconds timeLeft{-1};
+    int result{-1};
 
-    if (isTemporary()){
-        auto expire{std::chrono::system_clock::from_time_t(m_expireTime)};
-        auto target{std::chrono::system_clock::from_time_t(time)};
-        timeLeft = std::chrono::duration_cast<std::chrono::milliseconds>(expire - target);
+    if (isTemporary() && !isExpired(time)){
+        auto timeLeft = (m_expireTime - time) * 1000;
+
+        if (timeLeft < INT_MAX){
+            result = timeLeft;
+        }
+        else{
+            result = INT_MAX;
+        }
     }
 
-    return timeLeft;
+    return result;
 }
 
 std::string

--- a/src/lib/shared/SerialKey.h
+++ b/src/lib/shared/SerialKey.h
@@ -19,7 +19,6 @@
 
 #include <string>
 #include <ctime>
-#include <chrono>
 #include "EditionType.h"
 #include "SerialKeyType.h"
 #include "SerialKeyEdition.h"
@@ -40,7 +39,7 @@ public:
     bool                isTemporary() const;
     bool                isValid() const;
     time_t              daysLeft(time_t currentTime) const;
-    std::chrono::milliseconds getSpanLeft(time_t time = ::time(0)) const;
+    int                 getSpanLeft(time_t time = ::time(0)) const;
     std::string         email() const;
     Edition             edition() const;
     std::string         toString() const;

--- a/src/test/unittests/shared/SerialKeyTests.cpp
+++ b/src/test/unittests/shared/SerialKeyTests.cpp
@@ -229,7 +229,7 @@ TEST(SerialKeyTests, IsValidExpiredKey_false)
 TEST(SerialKeyTests, test_getSpanLeft)
 {
     SerialKey key;
-    std::chrono::milliseconds expected{-1};
+    int expected{-1};
     EXPECT_EQ(expected, key.getSpanLeft());
 }
 
@@ -237,8 +237,15 @@ TEST(SerialKeyTests, test_getSpanLeft_subscription)
 {
     // {v2;subscription;basic;Bob;1;email;company name;0;86400}
     SerialKey key("7B76323B737562736372697074696F6E3B62617369633B426F623B313B656D61696C3B636F6D70616E79206E616D653B303B38363430307D");
-    std::chrono::milliseconds expected{1000};
-    EXPECT_EQ(expected, key.getSpanLeft(86399));
+    EXPECT_EQ(1000, key.getSpanLeft(86399));
+    EXPECT_EQ(-1, key.getSpanLeft(86401));
+}
+
+TEST(SerialKeyTests, test_getSpanLeft_max_int)
+{
+    //"{v2;subscription;basic;Bob;1;email;company name;0;3147483647}"
+    SerialKey key("7B76323B737562736372697074696F6E3B62617369633B426F623B313B656D61696C3B636F6D70616E79206E616D653B303B333134373438333634377D");
+    EXPECT_EQ(INT_MAX, key.getSpanLeft(1));
 }
 
 

--- a/src/test/unittests/shared/SerialKeyTests.cpp
+++ b/src/test/unittests/shared/SerialKeyTests.cpp
@@ -17,6 +17,7 @@
 
 #define TEST_ENV
 
+#include <climits>
 #include "shared/SerialKey.h"
 
 #include "test/global/gtest.h"

--- a/src/test/unittests/synergy/ProtocolUtilTests.cpp
+++ b/src/test/unittests/synergy/ProtocolUtilTests.cpp
@@ -200,7 +200,7 @@ TEST_F(ProtocolUtilTests, readf_string)
 {
     const UInt8 Length = 200;
     const std::string Expected(Length, 'x');
-    std::array<UInt8, 4> StringSize = {0,0,0,Length};
+    std::array<UInt8, 4> StringSize{{0,0,0,Length}};
 
     EXPECT_CALL(stream, read(_, _))
         .WillOnce(
@@ -225,8 +225,8 @@ class ReadfIntTestFixture : public ::testing::TestWithParam< std::tuple<const ch
 public:
     MockStream stream;
     UInt8 StreamData1Byte = 10;
-    std::array<UInt8, 2> StreamData2Bytes = {0, 10};
-    std::array<UInt8, 4> StreamData4Bytes = {0, 0, 0, 10};
+    std::array<UInt8, 2> StreamData2Bytes{{0, 10}};
+    std::array<UInt8, 4> StreamData4Bytes{{0, 0, 0, 10}};
 
     UInt8* getStreamData(int size)
     {
@@ -287,7 +287,7 @@ TEST_P(ReadfIntVectorTestFixture, readf_int_vector)
     const std::vector<UInt8> Expected1Byte = {10,10};
     const std::vector<UInt16> Expected2Bytes = {10,10};
     const std::vector<UInt32> Expected4Bytes = {10,10};
-    std::array<UInt8, 4> StreamVectorSize = {0,0,0,2};
+    std::array<UInt8, 4> StreamVectorSize{{0,0,0,2}};
 
     const char* Format = std::get<0>(GetParam());
     int StreamDataSize = std::get<1>(GetParam());
@@ -345,7 +345,7 @@ TEST_P(ReadfIntAndStringTest, readf_int_and_string)
     const int ExpectedInt = 10;
     const UInt8 StringLength = 200;
     const std::string ExpectedString(StringLength, 'x');
-    std::array<UInt8, 4> StringSize = {0,0,0,StringLength};
+    std::array<UInt8, 4> StringSize{{0,0,0,StringLength}};
 
     const char* Format = std::get<0>(GetParam());
     int StreamDataSize = std::get<1>(GetParam());
@@ -400,10 +400,10 @@ INSTANTIATE_TEST_CASE_P(
 TEST_F(ProtocolUtilTests, readf_string_and_int4bytes)
 {
     const UInt8 ExpectedInt = 10;
-    std::array<UInt8, 4> StreamIntData = {0,0,0,ExpectedInt};
+    std::array<UInt8, 4> StreamIntData{{0,0,0,ExpectedInt}};
 
     const std::string ExpectedStr(32768, 'x');
-    std::array<UInt8, 4> Size = {0,0,128,0};
+    std::array<UInt8, 4> Size{{0,0,128,0}};
 
     EXPECT_CALL(stream, read(_, _))
         .WillOnce(
@@ -434,11 +434,11 @@ TEST_F(ProtocolUtilTests, readf_string_and_vector_int4bytes)
 {
     std::vector<UInt32> Actual = {};
     const std::vector<UInt32> Expected4Bytes = {10,10};
-    std::array<UInt8, 4> StreamVectorSize = {0,0,0,2};
-    std::array<UInt8, 4> StreamData4Bytes = {0, 0, 0, 10};
+    std::array<UInt8, 4> StreamVectorSize{{0,0,0,2}};
+    std::array<UInt8, 4> StreamData4Bytes{{0, 0, 0, 10}};
 
     const std::string ExpString(32768, 'x');
-    std::array<UInt8, 4> SizeString = {0,0,128,0};
+    std::array<UInt8, 4> SizeString{{0,0,128,0}};
 
     EXPECT_CALL(stream, read(_, _))
         .WillOnce(
@@ -475,11 +475,11 @@ TEST_F(ProtocolUtilTests, readf_vector_int4bytes_and_string)
 {
     std::vector<UInt32> Actual4Bytes = {};
     const std::vector<UInt32> Expected4Bytes = {10,10};
-    std::array<UInt8, 4> StreamVectorSize = {0,0,0,2};
-    std::array<UInt8, 4> StreamData4Bytes = {0, 0, 0, 10};
+    std::array<UInt8, 4> StreamVectorSize{{0,0,0,2}};
+    std::array<UInt8, 4> StreamData4Bytes{{0, 0, 0, 10}};
 
     const std::string ExpectedString(32768, 'x');
-    std::array<UInt8, 4> StringSize = {0,0,128,0};
+    std::array<UInt8, 4> StringSize{{0,0,128,0}};
 
     EXPECT_CALL(stream, read(_, _))
         .WillOnce(
@@ -605,7 +605,7 @@ TEST_F(ProtocolUtilTests, write_string_test)
 TEST_F(ProtocolUtilTests, write_raw_bytes_test)
 {
     const UInt32 Size = 5;
-    const std::array<UInt8, Size> Expected = {10, 20, 30, 40, 50};
+    const std::array<UInt8, Size> Expected{{10, 20, 30, 40, 50}};
     EXPECT_CALL(stream, write(EqVoidVectorInt1byte(Expected), Expected.size() + sizeof (UInt32)));
     ProtocolUtil::writef(&stream, "%S", Size, &Expected);
 }


### PR DESCRIPTION
Unfortunately we are not able to use std::chrono due to compilation errors on: centos7.6, ubuntu1604, debian9