### PR TITLE
fix for older compilers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,7 +12,7 @@ Bug fixes:
 - #6660 + #6582 Add missing XAtom for utf-8 handling with Xorg
 - #6814 The system asks to save twice. 
 - #6817 Configure requires dns_sd.h for enterprise version
-- #6826 SonarCloud Critical bugs
+- #6826 + #6829 SonarCloud Critical bugs
 - #6821 Blocker bugs found by sonar in synergy and in tests
 - #6825 The system requires google test even when tests are disabled with BUILD_TESTS=OFF
 

--- a/src/test/unittests/synergy/ServerArgsParsingTests.cpp
+++ b/src/test/unittests/synergy/ServerArgsParsingTests.cpp
@@ -41,7 +41,7 @@ TEST(ServerArgs, ServerArgs_will_construct_from_copy)
 {
     lib::synergy::ServerArgs serverArgs;
     serverArgs.m_display = "display0";
-    auto serverArgs2 {serverArgs};
+    lib::synergy::ServerArgs serverArgs2 {serverArgs};
     EXPECT_EQ(serverArgs.m_display, serverArgs2.m_display);
 }
 


### PR DESCRIPTION
It seems that compilers such as the one shipped with CentOS 7.6 can implement ```auto``` rather strangely; avoiding the issue by not using auto on this new test.