### PR TITLE
PR SonarCloud

### DIFF
--- a/.github/workflows/job-sonarcloud.yml
+++ b/.github/workflows/job-sonarcloud.yml
@@ -1,4 +1,4 @@
-name: SonarCloud Static Analisis
+name: SonarCloud Static Analysis
 
 on:
   push:

--- a/.github/workflows/job-sonarcloud.yml
+++ b/.github/workflows/job-sonarcloud.yml
@@ -3,7 +3,7 @@ name: SonarCloud Static Analisis
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
 
 jobs:


### PR DESCRIPTION
Fixes issue with PR #6872 where SonarCloud check is not able to use the Secret Token.  Also, fixes minor typo.

Changing the `pull_request` job to `pull_request_target`.

> [`pull_request_target`](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target)
>
> This event is similar to `pull_request`, except that it runs in the context of the base repository of the pull request, rather than in the merge commit. This means that you can more safely make your secrets available to the workflows triggered by the pull request, because only workflows defined in the commit on the base repository are run.
