### PR TITLE
Change OpenSSL paths

### DIFF
--- a/CI/Windows/windows-build.yml
+++ b/CI/Windows/windows-build.yml
@@ -196,15 +196,15 @@ steps:
       cd $(Build.Repository.LocalPath)\build32\installer\bin\Release\
       set FILENAME=$(prefix)_$(SYNERGY_VERSION)-$(SYNERGY_VERSION_STAGE).$(SYNERGY_REVISION)_windows_x86.msi
       ren "Synergy.msi" "%FILENAME%"
-      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe md5 %FILENAME% > %FILENAME%.checksum.txt
-      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe sha1 %FILENAME% >> %FILENAME%.checksum.txt
-      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe sha256 %FILENAME% >> %FILENAME%.checksum.txt
+      $(Build.Repository.LocalPath)\ext\openssl\openssl.exe md5 %FILENAME% > %FILENAME%.checksum.txt
+      $(Build.Repository.LocalPath)\ext\openssl\openssl.exe sha1 %FILENAME% >> %FILENAME%.checksum.txt
+      $(Build.Repository.LocalPath)\ext\openssl\openssl.exe sha256 %FILENAME% >> %FILENAME%.checksum.txt
       cd $(Build.Repository.LocalPath)\build64\installer\bin\Release\
       set FILENAME=$(prefix)_$(SYNERGY_VERSION)-$(SYNERGY_VERSION_STAGE).$(SYNERGY_REVISION)_windows_x64.msi
       ren "Synergy.msi" "%FILENAME%"
-      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe md5 %FILENAME% > %FILENAME%.checksum.txt
-      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe sha1 %FILENAME% >> %FILENAME%.checksum.txt
-      $(Build.Repository.LocalPath)\ext\openssl\windows\x64\bin\openssl.exe sha256 %FILENAME% >> %FILENAME%.checksum.txt
+      $(Build.Repository.LocalPath)\ext\openssl\openssl.exe md5 %FILENAME% > %FILENAME%.checksum.txt
+      $(Build.Repository.LocalPath)\ext\openssl\openssl.exe sha1 %FILENAME% >> %FILENAME%.checksum.txt
+      $(Build.Repository.LocalPath)\ext\openssl\openssl.exe sha256 %FILENAME% >> %FILENAME%.checksum.txt
     displayName: "Rename files"
 
   - task: CopyFilesOverSSH@0

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Bug fixes:
 - #6903 Save global settings
 - #6889 Systray Icon on Ubuntu Auto Start (take 2)
 - #6914 Fix for Qt Word Wrap on Mac
+- #6920 Windows Installer checksums
 
 Enhancements:
 - #6912 Removes UI for Screen Saver Sync and Files Drag and Drop


### PR DESCRIPTION
In the Azure pipelines CI for windows. We relied on the openssl.exe dep in the ext directory. I moved it and now I'm fixing the CI script.