### PR TITLE
Mac build failures

### DIFF
--- a/CI/MacOS/mac-build.yml
+++ b/CI/MacOS/mac-build.yml
@@ -30,7 +30,13 @@ steps:
         export PATH="$(Qt5_DIR)/bin:$PATH"
         mkdir build
         cd build
-        cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=$(version) -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES=Release ..
+        cmake \
+          -DCMAKE_OSX_DEPLOYMENT_TARGET=$(version) \
+          -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CONFIGURATION_TYPES=Release \
+          -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl \
+          -DOPENSSL_LIBRARIES=/usr/local/opt/openssl/lib ..
     displayName: 'Cmake standard'
     condition: eq(variables['buildType'], 'standard')
     env:
@@ -43,7 +49,14 @@ steps:
         export SYNERGY_ENTERPRISE=1
         mkdir build
         cd build
-        cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CONFIGURATION_TYPES=Release -DSYNERGY_ENTERPRISE=ON ..
+        cmake \
+          -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 \
+          -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CONFIGURATION_TYPES=Release \
+          -DSYNERGY_ENTERPRISE=ON \
+          -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl \
+          -DOPENSSL_LIBRARIES=/usr/local/opt/openssl/lib ..
     displayName: 'Cmake enterprise'
     condition: eq(variables['buildType'], 'enterprise')
     env:

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Bug fixes:
 - #6889 Systray Icon on Ubuntu Auto Start (take 2)
 - #6914 Fix for Qt Word Wrap on Mac
 - #6920 Windows Installer checksums
+- #6922 macOS CI build
 
 Enhancements:
 - #6912 Removes UI for Screen Saver Sync and Files Drag and Drop

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,10 +46,10 @@ jobs:
           image: symless/synergy-core:fedora30
           packager: rpm
           name: fedora30
-        centos7.6:
-          image: symless/synergy-core:centos7.6
-          packager: rpm
-          name: centos76
+        # centos7.6:
+        #   image: symless/synergy-core:centos7.6
+        #   packager: rpm
+        #   name: centos76
         centos8:
           image: sgad/synergy-core:centos8
           packager: rpm

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ jobs:
 
     strategy:
       matrix:
-        ubuntu1604:
-          image: symless/synergy-core:ubuntu16.04
-          packager: deb
-          name: ubuntu16
+        # ubuntu1604:
+        #   image: symless/synergy-core:ubuntu16.04
+        #   packager: deb
+        #   name: ubuntu16
         ubuntu1804:
           image: symless/synergy-core:ubuntu18.04
           packager: deb


### PR DESCRIPTION
Fixes macOS CI build and removes the Centos7.6 build until we are ready to deal with it.