### PR TITLE
SYNERGY-833 Add extra enterprise validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 option (BUILD_TESTS "Override building of tests" ON)
 option (ENABLE_COVERAGE "Build with coverage")
 
-if (DEFINED ENV{SYNERGY_ENTERPRISE} AND NOT "$ENV{SYNERGY_ENTERPRISE}" STREQUAL "")
+if ($ENV{SYNERGY_ENTERPRISE})
     option (SYNERGY_ENTERPRISE "Build Enterprise" ON)
 else()
     option (SYNERGY_ENTERPRISE "Build Enterprise" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 option (BUILD_TESTS "Override building of tests" ON)
 option (ENABLE_COVERAGE "Build with coverage")
 
-if (DEFINED ENV{SYNERGY_ENTERPRISE})
+if (DEFINED ENV{SYNERGY_ENTERPRISE} AND NOT "$ENV{SYNERGY_ENTERPRISE}" STREQUAL "")
     option (SYNERGY_ENTERPRISE "Build Enterprise" ON)
 else()
     option (SYNERGY_ENTERPRISE "Build Enterprise" OFF)

--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@ Bug fixes:
 - #6941 The application doesn't recognize old settings
 - #6945 Fix build for Raspberry Pi
 - #6946 Add build stage to filename
+- #6951 Fix issue creating standard version for Raspberry Pi
 
 Enhancements:
 - #6912 Removes UI for Screen Saver Sync and Files Drag and Drop


### PR DESCRIPTION
Adds an extra layer of validation on whether to build the enterprise version of the application. This makes creating workflows easier compared to having custom conditional logic in multiple places of the workflow in order to set or not set the environment variable.