### PR TITLE
SYNERGY-1015 remove cmake option for autoconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,12 +35,6 @@ else()
     option (SYNERGY_ENTERPRISE "Build Enterprise" OFF)
 endif()
 
-if (DEFINED ENV{SYNERGY_AUTOCONFIG})
-    option (SYNERGY_AUTOCONFIG "Build with Autoconfig" ON)
-else()
-    option (SYNERGY_AUTOCONFIG "Build without Autoconfig" OFF)
-endif()
-
 set (CMAKE_CXX_STANDARD 14)
 set (CMAKE_CXX_EXTENSIONS OFF)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -260,14 +254,6 @@ if (UNIX)
             list (APPEND libs Xi)
         endif()
 
-        if (NOT SYNERGY_ENTERPRISE AND SYNERGY_BUILD_LEGACY_GUI AND SYNERGY_AUTOCONFIG)
-            set (DnsSdlib "dns_sd.h")
-            set (CMAKE_EXTRA_INCLUDE_FILES "${CMAKE_EXTRA_INCLUDE_FILES};${DnsSdlib}")
-            check_include_files ("${DnsSdlib}" HAVE_DNS_SD)
-            if (NOT HAVE_DNS_SD)
-                message (FATAL_ERROR "Missing header: " ${DnsSdlib})
-            endif()
-        endif()
     endif()
 
     # For config.h, set some static values; it may be a good idea to make

--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,7 @@ Bug fixes:
 - #7011 Fix language synchronisation checkbox spelling
 - #7013 Wrong connection pop up appears if the user connects using a domain name which is assigned to list of IP's
 - #7014 Temporary disable language sync logic
+- #7020 Remove cmake option for autoconfig
 
 Enhancements:
 - #6954 Move language selection to advanced section

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -77,7 +77,3 @@ endif()
 if (SYNERGY_ENTERPRISE)
     add_definitions (-DSYNERGY_ENTERPRISE=1)
 endif()
-
-if (SYNERGY_AUTOCONFIG)
-   add_definitions (-DSYNERGY_AUTOCONFIG=1)
-endif()

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -40,12 +40,10 @@ find_program(MACDEPLOYQT_EXECUTABLE macdeployqt HINTS "${_qt_bin_dir}")
 if (SYNERGY_ENTERPRISE)
     list (REMOVE_ITEM LEGACY_GUI_SOURCE_FILES ${LEGACY_ACTIVATION_FILES})
     list (REMOVE_ITEM LEGACY_GUI_UI_FILES ${LEGACY_ACTIVATION_FILES})
-    list (REMOVE_ITEM LEGACY_GUI_SOURCE_FILES ${LEGACY_ZEROCONF_FILES})
 endif ()
 
-if (NOT SYNERGY_AUTOCONFIG)
-   list (REMOVE_ITEM LEGACY_GUI_SOURCE_FILES ${LEGACY_ZEROCONF_FILES})
-endif ()
+list (REMOVE_ITEM LEGACY_GUI_SOURCE_FILES ${LEGACY_ZEROCONF_FILES})
+
 
 if (WIN32)
     set (LEGACY_GUI_RC_FILES res/win/Synergy.rc)
@@ -63,35 +61,11 @@ add_executable (synergy WIN32
 include_directories (./src)
 target_link_libraries (synergy shared)
 
-if (NOT SYNERGY_ENTERPRISE AND SYNERGY_AUTOCONFIG)
-if (WIN32)
-    include_directories ($ENV{BONJOUR_SDK_HOME}/Include)
-    if (CMAKE_SIZEOF_VOID_P EQUAL 8)
-        find_library (
-            DNSSD_LIB dnssd.lib
-            HINTS ENV BONJOUR_SDK_HOME
-            PATH_SUFFIXES "Lib/x64"
-        )
-    else()
-        find_library (
-            DNSSD_LIB dnssd.lib
-            HINTS ENV BONJOUR_SDK_HOME
-            PATH_SUFFIXES "Lib/Win32"
-        )
-    endif()
-elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    target_link_libraries (synergy dns_sd)
-endif()
-endif()
-
 qt5_use_modules (synergy Core Widgets Network)
 target_compile_definitions (synergy PRIVATE -DSYNERGY_VERSION_STAGE="${SYNERGY_VERSION_STAGE}")
 target_compile_definitions (synergy PRIVATE -DSYNERGY_REVISION="${SYNERGY_REVISION}")
 
 if (WIN32)
-if (NOT SYNERGY_ENTERPRISE AND SYNERGY_AUTOCONFIG)
-    target_link_libraries (synergy ${DNSSD_LIB})
-endif ()
     set_target_properties (synergy PROPERTIES LINK_FLAGS "/NODEFAULTLIB:LIBCMT")
 endif()
 


### PR DESCRIPTION
This PR removes cmake option SYNERGY_AUTOCONFIG to disable ability to build synergy with unsupported autoconfig functionality. 
In the same time we still have SYNERGY_AUTOCONFIG checks in the code.
Code cleanup will be prepared under separate task 