### PR TITLE
SYNERGY-1047 Scroll doesn't work in case of macOS is server

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ Bug fixes:
 - #7015 Fix Windows service not starting up after sleep
 - #7036 Fix tray icon not changing theme on Big Sur
 - #7046 Fix MacOS 10.13 build
+- #7049 Scroll doesn't work in case of macOS is server
 
 Enhancements:
 - #6998 Remove functionality related to the screen saver synchronisation

--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -153,9 +153,6 @@ private:
     // get the current scroll wheel speed
     double                getScrollSpeed() const;
 
-    // get the current scroll wheel speed
-    double                getScrollSpeedFactor() const;
-
     // enable/disable drag handling for buttons 3 and up
     void                enableDragTimer(bool enable);
 

--- a/src/lib/platform/OSXScreen.mm
+++ b/src/lib/platform/OSXScreen.mm
@@ -1460,9 +1460,8 @@ OSXScreen::mapMacButtonToSynergy(UInt16 macButton) const
 SInt32
 OSXScreen::mapScrollWheelToSynergy(SInt32 x) const
 {
-	// return accelerated scrolling but not exponentially scaled as it is
-	// on the mac.
-	double d = (1.0 + getScrollSpeed()) * x / getScrollSpeedFactor();
+	// return accelerated scrolling
+	double d = (1.0 + getScrollSpeed()) * x;
 	return static_cast<SInt32>(m_scrollDirection * 120.0 * d);
 }
 
@@ -1498,12 +1497,6 @@ OSXScreen::getScrollSpeed() const
 	}
 
 	return scaling;
-}
-
-double
-OSXScreen::getScrollSpeedFactor() const
-{
-	return pow(10.0, getScrollSpeed());
 }
 
 void


### PR DESCRIPTION
There was an additional division to fix exponential scale on macOS. 
Looks like it was actual for old version because there is no exponential scale on actual macOS. 