### PR TITLE
SYNERGY-1229 Synergy is running after quit on Linux

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ Bug fixes:
 - #7082 Windows client doesn't resume connection after sleep
 - #7089 Modifier keys don't work on Microsoft Remote Desktop
 - #7091 Fix CMakeFileList for unittests
+- #7092 Synergy is running after quit on Linux
 
 Enhancements:
 - #7068 Add Synergy restart when settings changed

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -1506,6 +1506,13 @@ void MainWindow::enableClient(bool enable)
     }
 }
 
+void MainWindow::closeEvent(QCloseEvent* event)
+{
+#if defined (Q_OS_LINUX)
+    qApp->quit();
+#endif
+    QWidget::closeEvent(event);
+}
 
 void MainWindow::on_m_pRadioGroupServer_clicked(bool)
 {

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -1509,7 +1509,7 @@ void MainWindow::enableClient(bool enable)
 void MainWindow::closeEvent(QCloseEvent* event)
 {
 #if defined (Q_OS_LINUX)
-    qApp->quit();
+    QCoreApplication::quit();
 #endif
     QWidget::closeEvent(event);
 }

--- a/src/gui/src/MainWindow.h
+++ b/src/gui/src/MainWindow.h
@@ -195,6 +195,7 @@ public slots:
         void retranslateMenuBar();
         void enableServer(bool enable);
         void enableClient(bool enable);
+        void closeEvent(QCloseEvent* event) override;
 
 #if defined(Q_OS_WIN)
         bool isServiceRunning(QString name);


### PR DESCRIPTION
This PR is to close synergy using the X button and using quit on the panel on all Linux systems.
This solution was agreed with Andrea.