### PR TITLE
SYNERGY-1287 display language notifications only on client side

### DIFF
--- a/CI/job-doxygen.yml
+++ b/CI/job-doxygen.yml
@@ -3,7 +3,7 @@ jobs:
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-latest'
 
     steps:
       - script: |

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@ v1.14.2-snapshot
 ===========
 Bug fixes:
 - #7070 Fix radio button shifted focus on macOS
-- #7038 | #7104 Fix client and server different keyboard layout errors
+- #7038 | #7104 | #7111 Fix client and server different keyboard layout errors
 - #7078 Fix clipboard re-enables automatically
 - #7077 Fix Ubuntu, CentOS and Debian build after SYNERGY-1161
 - #7080 Add trace if the system can't open file with trusted fingerprints

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -752,10 +752,7 @@ Client::handleHello(const Event&, void*)
 
     // say hello back
     LOG((CLOG_DEBUG1 "say hello version %d.%d", helloBackMajor, helloBackMinor));
-    auto localLanguages = m_languageManager.getSerializedLocalLanguages();
-    ProtocolUtil::writef(m_stream, kMsgHelloBack,
-                            helloBackMajor,
-                            helloBackMinor, & m_name, &localLanguages);
+    ProtocolUtil::writef(m_stream, kMsgHelloBack, helloBackMajor, helloBackMinor, &m_name);
 
     // now connected but waiting to complete handshake
     setupScreen();

--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -817,15 +817,11 @@ Client::onFileRecieveCompleted()
 void
 Client::checkMissedLanguages() const
 {
-    if (m_args.m_enableLangSync) {
-        auto missedLanguages = m_languageManager.getMissedLanguages();
-        if (!missedLanguages.empty()) {
-            AppUtil::instance().showNotification("Language synchronization error",
-                                                 "These languages are required for the client to work: " + missedLanguages);
-        }
-    }
-    else {
-        LOG((CLOG_DEBUG "Language sync logic is disabled."));
+    auto missedLanguages = m_languageManager.getMissedLanguages();
+    if (!missedLanguages.empty()) {
+        AppUtil::instance().showNotification("Language synchronization error",
+              "You need to install these languages on this computer to enable support for multiple languages: "
+              + missedLanguages);
     }
 }
 

--- a/src/lib/server/ClientProxyUnknown.cpp
+++ b/src/lib/server/ClientProxyUnknown.cpp
@@ -194,13 +194,9 @@ ClientProxyUnknown::handleData(const Event&, void*)
 
         // parse the reply to hello
         SInt16 major, minor;
-        String remoteLanguages;
-        if (!ProtocolUtil::readf(m_stream, kMsgHelloBack,
-                                    &major, &minor, &name, &remoteLanguages)) {
+        if (!ProtocolUtil::readf(m_stream, kMsgHelloBack, &major, &minor, &name)) {
             throw XBadClient();
         }
-        m_languageManager.setRemoteLanguages(remoteLanguages);
-        m_server->setLanguageManager(m_languageManager);
 
         // disallow invalid version numbers
         if (major <= 0 || minor < 0) {

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -348,8 +348,6 @@ Server::adoptClient(BaseClientProxy* client)
 		client->screensaver(true);
 	}
 
-	checkMissedLanguages();
-
 	// send notification
 	Server::ScreenConnectedInfo* info =
 		new Server::ScreenConnectedInfo(getName(client));
@@ -1930,16 +1928,6 @@ Server::sendDragInfo(BaseClientProxy* newScreen)
 		LOG((CLOG_DEBUG3 "dragging file list: %s", info));
 		LOG((CLOG_DEBUG3 "dragging file list string size: %i", size));
 		newScreen->sendDragInfo(fileCount, info, size);
-	}
-}
-
-void
-Server::checkMissedLanguages() const
-{
-	auto missedLanguages = m_languageManager.getMissedLanguages();
-	if (!missedLanguages.empty()) {
-		AppUtil::instance().showNotification("Language synchronization error",
-											"These languages are required for the server to work: " + missedLanguages);
 	}
 }
 

--- a/src/lib/server/Server.h
+++ b/src/lib/server/Server.h
@@ -157,9 +157,6 @@ public:
     //! Store ClientListener pointer
     void                setListener(ClientListener* p) { m_clientListener = p; }
 
-    //! Set language manager
-    void                setLanguageManager(const synergy::languages::LanguageManager& manager) { m_languageManager = manager; }
-
     //@}
     //! @name accessors
     //@{
@@ -377,9 +374,6 @@ private:
     // send drag info to new client screen
     void                sendDragInfo(BaseClientProxy* newScreen);
 
-    //Shows notification if there are missed languages
-    void                checkMissedLanguages() const;
-
 public:
     bool                m_mock;
 
@@ -494,5 +488,4 @@ private:
 
     ClientListener*        m_clientListener;
     lib::synergy::ServerArgs            m_args;
-    synergy::languages::LanguageManager m_languageManager;
 };

--- a/src/lib/synergy/protocol_types.cpp
+++ b/src/lib/synergy/protocol_types.cpp
@@ -19,7 +19,7 @@
 #include "synergy/protocol_types.h"
 
 const char* const               kMsgHello            = "Synergy%2i%2i%s";
-const char* const               kMsgHelloBack        = "Synergy%2i%2i%s%s";
+const char* const               kMsgHelloBack        = "Synergy%2i%2i%s";
 const char* const               kMsgCNoop             = "CNOP";
 const char* const               kMsgCClose             = "CBYE";
 const char* const               kMsgCEnter             = "CINN%2i%2i%4i%2i";

--- a/src/lib/synergy/protocol_types.h
+++ b/src/lib/synergy/protocol_types.h
@@ -109,7 +109,7 @@ extern const char* const       kMsgHello;
 // respond to hello from server;  secondary -> primary
 // $1 = protocol major version number supported by client.  $2 =
 // protocol minor version number supported by client.  $3 = client
-// name. $4 = client language list
+// name.
 extern const char* const       kMsgHelloBack;
 
 


### PR DESCRIPTION
Under this PR the following changes were implemented:
1. Removed language notification on the server side.
2. Enable notification on the client side even if sync is off.
3. Notification message was changed according to the task SYNERGY-1287
4. Changed Doxygen job to use ubuntu-latest instead of ubuntu-16 because ubuntu-16 is no available anymore on Azure Pipelines.
