### PR TITLE
Fix double lines when pasting text from Linux to Windows

### DIFF
--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -83,9 +83,9 @@ XWindowsClipboard::XWindowsClipboard(Display* display,
                                 "application/x-moz-nativehtml"));
     m_converters.push_back(new XWindowsClipboardBMPConverter(m_display));
     m_converters.push_back(new XWindowsClipboardUTF8Converter(m_display,
-                                "text/plain;charset=UTF-8"));
+                                "text/plain;charset=UTF-8", true));
     m_converters.push_back(new XWindowsClipboardUTF8Converter(m_display,
-                                "text/plain;charset=utf-8"));
+                                "text/plain;charset=utf-8", true));
     m_converters.push_back(new XWindowsClipboardUTF8Converter(m_display,
                                 "UTF8_STRING"));
     m_converters.push_back(new XWindowsClipboardUCS2Converter(m_display,

--- a/src/lib/platform/XWindowsClipboardUTF8Converter.h
+++ b/src/lib/platform/XWindowsClipboardUTF8Converter.h
@@ -26,7 +26,7 @@ public:
     /*!
     \c name is converted to an atom and that is reported by getAtom().
     */
-    XWindowsClipboardUTF8Converter(Display* display, const char* name);
+    XWindowsClipboardUTF8Converter(Display* display, const char* name, bool normalize = false);
     virtual ~XWindowsClipboardUTF8Converter();
 
     // IXWindowsClipboardConverter overrides
@@ -39,4 +39,5 @@ public:
 
 private:
     Atom                m_atom;
+    bool                m_normalize;
 };


### PR DESCRIPTION
GTK normalizes line endings in the clipboard to CRLF for the text/plain;charset=utf-8 clipboard format.

This results in double lines when pasting text copied from Linux to Windows because the Windows client converts line endings and expects only LF.