### PR TITLE
SYNERGY3-150 Fix unstable build for windows core

### DIFF
--- a/.github/workflows/aws-upload-windows.yml
+++ b/.github/workflows/aws-upload-windows.yml
@@ -3,7 +3,7 @@ name: Windows - Core
 on:
   release:
     types: [published]
-  # pull_request:
+  pull_request:
 
 jobs:
   build-core-windows:
@@ -50,7 +50,10 @@ jobs:
           cd build
           cmake -DCMAKE_BUILD_TYPE=Release ..
           . ./version
-          msbuild synergy-core.sln /p:Configuration=Release
+          msbuild synergy-core.sln `
+            /p:Platform="x64"
+            /p:Configuration=Release `
+            /m
 
       - uses: anshulrgoyal/upload-s3-action@master
         if: "github.event_name == 'release'"

--- a/.github/workflows/aws-upload-windows.yml
+++ b/.github/workflows/aws-upload-windows.yml
@@ -3,7 +3,7 @@ name: Windows - Core
 on:
   release:
     types: [published]
-  pull_request:
+  # pull_request:
 
 jobs:
   build-core-windows:

--- a/.github/workflows/aws-upload-windows.yml
+++ b/.github/workflows/aws-upload-windows.yml
@@ -51,7 +51,7 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=Release ..
           . ./version
           msbuild synergy-core.sln `
-            /p:Platform="x64"
+            /p:Platform="x64" `
             /p:Configuration=Release `
             /m
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,9 @@ v1.14.4-snapshot
 ===========
 Enhancements:
 - #7143 Add ability to stop synergy on the login screen
+
+Github Actions:
+- #7148 Fix unstable build for windows core
 ===========
 
 v1.14.3-snapshot

--- a/scripts/buildCoreWindows.ps1
+++ b/scripts/buildCoreWindows.ps1
@@ -100,8 +100,8 @@ Try {
   . ./version
   msbuild synergy-core.sln `
     /p:Configuration=$env:SYNERGY_BUILD_TYPE `
-    # /p:Platform="x64" `
-    # /m
+    /p:Platform="x64" `
+    /m
 
   Remove-Item -Force -Path "synergy-core-win-x64.zip" -ErrorAction SilentlyContinue
   Compress-Archive `

--- a/scripts/buildCoreWindows.ps1
+++ b/scripts/buildCoreWindows.ps1
@@ -95,16 +95,15 @@ New-Item `
 Push-Location $env:SYNERGY_BUILD_DIRECTORY
 Try {
   cmake `
-    -G "Visual Studio 16 2019" `
     -DCMAKE_BUILD_TYPE=$env:SYNERGY_BUILD_TYPE `
     ..
-
+  . ./version
   msbuild synergy-core.sln `
-    /p:Platform="x64" `
     /p:Configuration=$env:SYNERGY_BUILD_TYPE `
-    /m `
-    /t:synergys `
-    /t:synergyc
+    # /p:Platform="x64" `
+    # /m
+
+  Remove-Item -Force -Path "synergy-core-win-x64.zip" -ErrorAction SilentlyContinue
   Compress-Archive `
     -Path ".\bin\${env:SYNERGY_BUILD_TYPE}\*" `
     -DestinationPath "synergy-core-win-x64.zip"


### PR DESCRIPTION
Fix unstable build for synergy-core binaries on windows. Seems that specifying `x64` makes it work.