### PR TITLE
SYNERGY1-1497 Fix memory leaks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,7 +8,7 @@ Bug fixes:
 - #7144 Fix double lines when pasting text from Linux to Windows
 - #7149 Address issues with modifiers and dead keys
 - #7163 Fix compilation issues for FreeBSD
-- #7164 Fix memory leaks
+- #7164 Fix memory leaks in language sync and TLS functionality
 
 Github Actions:
 - #7148 Fix unstable build for windows core

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ Bug fixes:
 - #7144 Fix double lines when pasting text from Linux to Windows
 - #7149 Address issues with modifiers and dead keys
 - #7163 Fix compilation issues for FreeBSD
+- #7164 Fix memory leaks
 
 Github Actions:
 - #7148 Fix unstable build for windows core

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -77,31 +77,13 @@ SecureSocket::SecureSocket(IEventQueue* events,
 
 SecureSocket::~SecureSocket()
 {
-    isFatal(true);
-    // take socket from multiplexer ASAP otherwise the race condition
-    // could cause events to get called on a dead object. TCPSocket
-    // will do this, too, but the double-call is harmless
-    setJob(NULL);
-    if (m_ssl->m_ssl != NULL) {
-        SSL_shutdown(m_ssl->m_ssl);
-
-        SSL_free(m_ssl->m_ssl);
-        m_ssl->m_ssl = NULL;
-    }
-    if (m_ssl->m_context != NULL) {
-        SSL_CTX_free(m_ssl->m_context);
-        m_ssl->m_context = NULL;
-    }
-    delete m_ssl;
+    freeSSL();
 }
 
 void
 SecureSocket::close()
 {
-    isFatal(true);
-
-    SSL_shutdown(m_ssl->m_ssl);
-
+    freeSSL();
     TCPSocket::close();
 }
 
@@ -413,6 +395,27 @@ SecureSocket::createSSL()
         assert(m_ssl->m_context != NULL);
         m_ssl->m_ssl = SSL_new(m_ssl->m_context);
     }
+}
+
+void
+SecureSocket::freeSSL()
+{
+    isFatal(true);
+    // take socket from multiplexer ASAP otherwise the race condition
+    // could cause events to get called on a dead object. TCPSocket
+    // will do this, too, but the double-call is harmless
+    setJob(NULL);
+    if (m_ssl->m_ssl != NULL) {
+        SSL_shutdown(m_ssl->m_ssl);
+
+        SSL_free(m_ssl->m_ssl);
+        m_ssl->m_ssl = NULL;
+    }
+    if (m_ssl->m_context != NULL) {
+        SSL_CTX_free(m_ssl->m_context);
+        m_ssl->m_context = NULL;
+    }
+    delete m_ssl;
 }
 
 int

--- a/src/lib/net/SecureSocket.h
+++ b/src/lib/net/SecureSocket.h
@@ -67,6 +67,7 @@ private:
     // SSL
     void                initContext(bool server);
     void                createSSL();
+    void                freeSSL();
     int                 secureAccept(int s);
     int                 secureConnect(int s);
     bool                showCertificate();
@@ -90,7 +91,7 @@ private:
     void                showSecureConnectInfo();
     void                showSecureLibInfo();
     void                showSecureCipherInfo();
-    
+
     void                handleTCPConnected(const Event& event, void*);
 
 private:

--- a/src/lib/platform/OSXAutoTypes.h
+++ b/src/lib/platform/OSXAutoTypes.h
@@ -1,0 +1,28 @@
+/*
+ * synergy -- mouse and keyboard sharing utility
+ * Copyright (C) 2016 Symless Ltd.
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#if WINAPI_CARBON
+#include <memory>
+#include <Carbon/Carbon.h>
+
+using CFDeallocator = decltype(&CFRelease);
+using AutoCFArray = std::unique_ptr<const __CFArray, CFDeallocator>;
+using AutoCFDictionary = std::unique_ptr<const __CFDictionary, CFDeallocator>;
+using AutoTISInputSourceRef = std::unique_ptr<__TISInputSource, CFDeallocator>;
+
+#endif

--- a/src/lib/platform/OSXAutoTypes.h
+++ b/src/lib/platform/OSXAutoTypes.h
@@ -1,6 +1,6 @@
 /*
  * synergy -- mouse and keyboard sharing utility
- * Copyright (C) 2016 Symless Ltd.
+ * Copyright (C) 2022 Symless Ltd.
  *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -910,13 +910,13 @@ OSXKeyState::handleModifierKey(void* target,
 }
 
 bool
-OSXKeyState::getGroups(GroupList& groups) const
+OSXKeyState::getGroups(AutoCFArray& groups) const
 {
     // get number of layouts
     CFStringRef keys[] = { kTISPropertyInputSourceCategory };
     CFStringRef values[] = { kTISCategoryKeyboardInputSource };
     AutoCFDictionary dict(CFDictionaryCreate(NULL, (const void **)keys, (const void **)values, 1, NULL, NULL), CFRelease);
-    GroupList kbds(TISCreateInputSourceList(dict.get(), false), CFRelease);
+    AutoCFArray kbds(TISCreateInputSourceList(dict.get(), false), CFRelease);
 
     if (CFArrayGetCount(kbds.get()) > 0) {
         groups = std::move(kbds);

--- a/src/lib/platform/OSXKeyState.h
+++ b/src/lib/platform/OSXKeyState.h
@@ -22,6 +22,7 @@
 #include "common/stdmap.h"
 #include "common/stdset.h"
 #include "common/stdvector.h"
+#include "OSXAutoTypes.h"
 
 #include <Carbon/Carbon.h>
 
@@ -107,11 +108,6 @@ protected:
 
 private:
     class KeyResource;
-    typedef void(*CFDeallocator)(CFTypeRef);
-    typedef std::unique_ptr<const __CFArray, CFDeallocator> GroupList;
-    typedef std::unique_ptr<const __CFDictionary, CFDeallocator> AutoCFDictionary;
-    typedef std::unique_ptr<__TISInputSource, CFDeallocator> AutoTISInputSourceRef;
-
 
     // Add hard coded special keys to a synergy::KeyMap.
     void                getKeyMapForSpecialKeys(
@@ -122,7 +118,7 @@ private:
                             SInt32 group, const IOSXKeyResource& r) const;
 
     // Get the available keyboard groups
-    bool                getGroups(GroupList&) const;
+    bool                getGroups(AutoCFArray&) const;
 
     // Change active keyboard group to group
     void                setGroup(SInt32 group);
@@ -176,9 +172,9 @@ private:
     typedef std::map<CFDataRef, SInt32> GroupMap;
     typedef std::map<UInt32, KeyID> VirtualKeyMap;
 
-    VirtualKeyMap        m_virtualKeyMap;
-    mutable UInt32        m_deadKeyState;
-    GroupList           m_groups{nullptr, CFRelease};
+    VirtualKeyMap       m_virtualKeyMap;
+    mutable UInt32      m_deadKeyState;
+    AutoCFArray         m_groups{nullptr, CFRelease};
     GroupMap            m_groupMap;
     bool                m_shiftPressed;
     bool                m_controlPressed;

--- a/src/lib/synergy/unix/AppUtilUnix.cpp
+++ b/src/lib/synergy/unix/AppUtilUnix.cpp
@@ -25,6 +25,7 @@
 #include <X11/XKBlib.h>
 #elif WINAPI_CARBON
 #include <Carbon/Carbon.h>
+#include <platform/OSXAutoTypes.h>
 #else
 #error Platform not supported.
 #endif
@@ -71,11 +72,11 @@ AppUtilUnix::getKeyboardLayoutList()
 #elif WINAPI_CARBON
     CFStringRef keys[] = { kTISPropertyInputSourceCategory };
     CFStringRef values[] = { kTISCategoryKeyboardInputSource };
-    CFDictionaryRef dict = CFDictionaryCreate(NULL, (const void **)keys, (const void **)values, 1, NULL, NULL);
-    CFArrayRef kbds = TISCreateInputSourceList(dict, false);
+    AutoCFDictionary dict(CFDictionaryCreate(NULL, (const void **)keys, (const void **)values, 1, NULL, NULL), CFRelease);
+    AutoCFArray kbds(TISCreateInputSourceList(dict.get(), false), CFRelease);
 
-    for (CFIndex i = 0; i < CFArrayGetCount(kbds); ++i) {
-        TISInputSourceRef keyboardLayout = (TISInputSourceRef)CFArrayGetValueAtIndex(kbds, i);
+    for (CFIndex i = 0; i < CFArrayGetCount(kbds.get()); ++i) {
+        TISInputSourceRef keyboardLayout = (TISInputSourceRef)CFArrayGetValueAtIndex(kbds.get(), i);
         auto layoutLanguages = (CFArrayRef)TISGetInputSourceProperty(keyboardLayout, kTISPropertyInputSourceLanguages);
         char temporaryCString[128] = {0};
         for(CFIndex index = 0; index < CFArrayGetCount(layoutLanguages) && layoutLanguages; index++) {


### PR DESCRIPTION
This PR fixed the following memory leaks:
1. In function getKeyboardLayoutList call for CFDictionaryCreat and TISCreateInputSourceList
2. A new function freeSSL to call free SSL memory from destructor and function close