### PR TITLE
SYNERGY1-1497 memory leaks in synergyc on mac os

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,7 @@ Bug fixes:
 - #7144 Fix double lines when pasting text from Linux to Windows
 - #7149 Address issues with modifiers and dead keys
 - #7163 Fix compilation issues for FreeBSD
-- #7164 | #7170 Fix memory leaks in language sync and TLS functionality
+- #7172 Memory leaks in language sync and TLS functionality
 
 Github Actions:
 - #7148 Fix unstable build for windows core

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,7 @@ Bug fixes:
 - #7144 Fix double lines when pasting text from Linux to Windows
 - #7149 Address issues with modifiers and dead keys
 - #7163 Fix compilation issues for FreeBSD
-- #7164 Fix memory leaks in language sync and TLS functionality
+- #7164 | #7170 Fix memory leaks in language sync and TLS functionality
 
 Github Actions:
 - #7148 Fix unstable build for windows core

--- a/src/lib/arch/win32/ArchNetworkWinsock.cpp
+++ b/src/lib/arch/win32/ArchNetworkWinsock.cpp
@@ -734,15 +734,15 @@ ArchNetworkWinsock::nameToAddr(const std::string& name)
         throwNameError(ret);
     }
 
-    for(; pResult != nullptr; pResult = pResult->ai_next ){
+    for(auto address = pResult; address != nullptr; address = address->ai_next ){
         addresses.push_back(new ArchNetAddressImpl);
-        if (pResult->ai_family == AF_INET) {
+        if (address->ai_family == AF_INET) {
             addresses.back()->m_len = (socklen_t)sizeof(struct sockaddr_in);
         } else {
             addresses.back()->m_len = (socklen_t)sizeof(struct sockaddr_in6);
         }
 
-        memcpy(&addresses.back()->m_addr, pResult->ai_addr, addresses.back()->m_len);
+        memcpy(&addresses.back()->m_addr, address->ai_addr, addresses.back()->m_len);
     }
 
     freeaddrinfo(pResult);

--- a/src/lib/net/NetworkAddress.cpp
+++ b/src/lib/net/NetworkAddress.cpp
@@ -152,10 +152,13 @@ NetworkAddress::resolve(size_t index)
             // Logic for temporary filtring only ipv4 addresses
             std::vector<ArchNetAddress> ipv4OnlyAddresses;
             {
-                auto adresses = ARCH->nameToAddr(m_hostname);
-                for (auto address : adresses) {
+                auto addresses = ARCH->nameToAddr(m_hostname);
+                for (auto address : addresses) {
                     if (ARCH->getAddrFamily(address) == IArchNetwork::kINET) {
                         ipv4OnlyAddresses.emplace_back(address);
+                    }
+                    else {
+                        ARCH->closeAddr(address);
                     }
                 }
             }

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -683,12 +683,13 @@ bool
 SecureSocket::verifyCertFingerprint()
 {
     // calculate received certificate fingerprint
-    X509 *cert = cert = SSL_get_peer_certificate(m_ssl->m_ssl);
-    EVP_MD* tempDigest;
+    using AutoX509 = std::unique_ptr<X509, decltype (&X509_free)>;
+    AutoX509 cert(SSL_get_peer_certificate(m_ssl->m_ssl), X509_free);
+
     unsigned char tempFingerprint[EVP_MAX_MD_SIZE];
     unsigned int tempFingerprintLen;
-    tempDigest = (EVP_MD*)EVP_sha256();
-    int digestResult = X509_digest(cert, tempDigest, tempFingerprint, &tempFingerprintLen);
+    EVP_MD* tempDigest = (EVP_MD*)EVP_sha256();
+    int digestResult = X509_digest(cert.get(), tempDigest, tempFingerprint, &tempFingerprintLen);
 
     if (digestResult <= 0) {
         LOG((CLOG_ERR "failed to calculate fingerprint, digest result: %d", digestResult));

--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -684,12 +684,11 @@ SecureSocket::verifyCertFingerprint()
 {
     // calculate received certificate fingerprint
     using AutoX509 = std::unique_ptr<X509, decltype (&X509_free)>;
-    AutoX509 cert(SSL_get_peer_certificate(m_ssl->m_ssl), X509_free);
+    AutoX509 cert(SSL_get_peer_certificate(m_ssl->m_ssl), &X509_free);
 
     unsigned char tempFingerprint[EVP_MAX_MD_SIZE];
     unsigned int tempFingerprintLen;
-    EVP_MD* tempDigest = (EVP_MD*)EVP_sha256();
-    int digestResult = X509_digest(cert.get(), tempDigest, tempFingerprint, &tempFingerprintLen);
+    int digestResult = X509_digest(cert.get(), EVP_sha256(), tempFingerprint, &tempFingerprintLen);
 
     if (digestResult <= 0) {
         LOG((CLOG_ERR "failed to calculate fingerprint, digest result: %d", digestResult));

--- a/src/lib/platform/OSXScreenSaver.cpp
+++ b/src/lib/platform/OSXScreenSaver.cpp
@@ -28,7 +28,7 @@
 
 // TODO: upgrade deprecated function usage in these functions.
 void getProcessSerialNumber(const char* name, ProcessSerialNumber& psn);
-bool testProcessName(const char* name, const ProcessSerialNumber& psn);
+bool isScreenSaverEngine(const ProcessSerialNumber& psn);
 
 //
 // OSXScreenSaver
@@ -106,7 +106,7 @@ OSXScreenSaver::isActive() const
 void
 OSXScreenSaver::processLaunched(ProcessSerialNumber psn)
 {
-    if (testProcessName("ScreenSaverEngine", psn)) {
+    if (isScreenSaverEngine(psn)) {
         m_screenSaverPSN = psn;
         LOG((CLOG_DEBUG1 "ScreenSaverEngine launched. Enabled=%d", m_enabled));
         if (m_enabled) {
@@ -191,11 +191,14 @@ getProcessSerialNumber(const char* name, ProcessSerialNumber& psn)
 }
 
 bool
-testProcessName(const char* name, const ProcessSerialNumber& psn)
+isScreenSaverEngine(const ProcessSerialNumber& psn)
 {
-    CFStringRef    processName;
+    CFStringRef processName;
     OSStatus    err = CopyProcessName(&psn, &processName);
-    return (err == 0 && CFEqual(CFSTR("ScreenSaverEngine"), processName));
+    bool result = (err == 0 && CFEqual(CFSTR("ScreenSaverEngine"), processName));
+    CFRelease(processName);
+
+    return result;
 }
 
 #pragma GCC diagnostic error "-Wdeprecated-declarations"


### PR DESCRIPTION
The following memory leaks were fixed:
1. In `isScreenSaverEngine` free memory allocated by `CopyProcessName`
2. In `nameToAddr` free memory allocated by `getaddrinfo`
3. In ​​`SecureSocket::verifyCertFingerprint` free memory allocated by `SSL_get_peer_certificate`

Sonar shows some code duplication which we had previously.
It requires some refactoring which will increase testing scope hence it should be done under a separate task.
