### PR TITLE
to fix a typo

### DIFF
--- a/src/lib/synergy/unix/SynergyXkbKeyboard.cpp
+++ b/src/lib/synergy/unix/SynergyXkbKeyboard.cpp
@@ -37,7 +37,7 @@ SynergyXkbKeyboard::SynergyXkbKeyboard()
         }
     }
     else {
-        LOG((CLOG_WARN "Can't open Xkb diaplay during reading languages"));
+        LOG((CLOG_WARN "Can't open Xkb display during reading languages"));
     }
 }
 


### PR DESCRIPTION
diff --git a/src/lib/synergy/unix/SynergyXkbKeyboard.cpp b/src/lib/synergy/unix/SynergyXkbKeyboard.cpp
index 81e78613..2c1fc680 100644
--- a/src/lib/synergy/unix/SynergyXkbKeyboard.cpp
+++ b/src/lib/synergy/unix/SynergyXkbKeyboard.cpp
@@ -37,7 +37,7 @@ SynergyXkbKeyboard::SynergyXkbKeyboard()
         }
     }
     else {
-        LOG((CLOG_WARN "Can't open Xkb diaplay during reading languages"));
+        LOG((CLOG_WARN "Can't open Xkb display during reading languages"));
     }
 }