### PR TITLE
XSync to not miss key repeat

### DIFF
--- a/src/lib/platform/XWindowsScreen.cpp
+++ b/src/lib/platform/XWindowsScreen.cpp
@@ -1241,6 +1241,8 @@ XWindowsScreen::handleSystemEvent(const Event& event, void*)
 			filter.m_time    = xevent->xkey.time;
 			filter.m_keycode = xevent->xkey.keycode;
 			XEvent xevent2;
+			if(!XQLength(m_display))
+				XSync(m_display, False);
 			isRepeat = (XCheckIfEvent(m_display, &xevent2,
 							&XWindowsScreen::findKeyEvent,
 							(XPointer)&filter) == True);


### PR DESCRIPTION
SYNERGY1-949

This PR cherrypicks the interesting commit from @Unknow0. #6986

> Hi,
>
> this is a fix for https://github.com/symless/synergy-core/issues/6985
>
> the XSync when the x event queue is empty make the key repeatition detection never fail.
>
> Regards.