### PR TITLE
Use vertical scroll on the about screen

### DIFF
--- a/src/gui/src/AboutDialog.cpp
+++ b/src/gui/src/AboutDialog.cpp
@@ -33,7 +33,7 @@ AboutDialog::AboutDialog(MainWindow* parent, const AppConfig& config) :
 	setupCreditsLoader();
 
 	QString aboutText(R"(<p>
-Keyboard and mouse sharing application. Cross platform and open source.<br /><br />
+Keyboard and mouse sharing application. Cross platform and open source since 2001.<br /><br />
 Copyright © %%YEAR%% Symless Ltd.<br /><br />
 Synergy is released under the GNU General Public License (GPLv2).</p>
 <p style="font-size: 14px">Key contributors<br>

--- a/src/gui/src/AboutDialog.cpp
+++ b/src/gui/src/AboutDialog.cpp
@@ -81,11 +81,15 @@ Daun Chung, Serhii Hadzhylov, Oleksandr Lysytsia, Olena Kutytska, Francisco Maga
 
 void AboutDialog::setupCreditsLoader()
 {
+	this->textEliteBackers->setText("Loading...");
+	this->textEliteBackers->viewport()->setAutoFillBackground(false);
+	this->textEliteBackers->document()->setDocumentMargin(0);
+
 	connect(&credits, SIGNAL(loaded(const QString&)), this, SLOT(updateEliteBackers(const QString&)));
 	credits.loadEliteBackers();
 }
 
 void AboutDialog::updateEliteBackers(const QString& eliteBackers) const
 {
-	this->labelEliteBackersData->setText(eliteBackers);
+	this->textEliteBackers->setText(eliteBackers);
 }

--- a/src/gui/src/AboutDialog.cpp
+++ b/src/gui/src/AboutDialog.cpp
@@ -42,7 +42,7 @@ Ryan Breen, Guido Poschta, Bertrand Landry Hetu, Tom Chadwick, Brent Priddy, Kyl
 Daun Chung, Serhii Hadzhylov, Oleksandr Lysytsia, Olena Kutytska, Francisco Magalhães.</span>
 </p>)");
 
-	m_versionChecker.setApp(config.synergycName());
+	m_versionChecker.setApp(parent->appPath(config.synergycName()));
 	QString version = m_versionChecker.getVersion();
 #ifdef SYNERGY_REVISION
     version +=  '-';

--- a/src/gui/src/AboutDialogBase.ui
+++ b/src/gui/src/AboutDialogBase.ui
@@ -121,70 +121,16 @@
       </widget>
      </item>
      <item>
-      <widget class="QScrollArea" name="scrollAreaEliteBackers">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
+      <widget class="QTextBrowser" name="textEliteBackers">
+       <property name="styleSheet">
+        <string notr="true">font-size: 11px;</string>
        </property>
        <property name="frameShape">
         <enum>QFrame::NoFrame</enum>
        </property>
-       <property name="widgetResizable">
-        <bool>true</bool>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
        </property>
-       <widget class="QWidget" name="scrollAreaWidgetContents">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>0</y>
-          <width>419</width>
-          <height>83</height>
-         </rect>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>3</number>
-         </property>
-         <property name="rightMargin">
-          <number>3</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="labelEliteBackersData">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>10</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>-1</pointsize>
-            </font>
-           </property>
-           <property name="styleSheet">
-            <string notr="true">font-size: 11px;s</string>
-           </property>
-           <property name="text">
-            <string>Loading...</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
This PR fixed the following issues:
1. Horizontal scrolling for elite backers 
2. Update about text
3. Fix issue with version number on macOS