### PR TITLE
Fix the free order

### DIFF
--- a/src/lib/synergy/unix/AppUtilUnix.cpp
+++ b/src/lib/synergy/unix/AppUtilUnix.cpp
@@ -148,8 +148,8 @@ AppUtilUnix::getCurrentLanguageCode()
           groupStartI = strI + 1;
       }
 
-      XFree(kbdDescr);
       XkbFreeNames(kbdDescr, XkbSymbolsNameMask, true);
+      XFree(kbdDescr);
       XCloseDisplay(display);
 
       result = X11LayoutsParser::convertLayotToISO("/usr/share/X11/xkb/rules/evdev.xml", result);


### PR DESCRIPTION
Currently, XFree(kbdDescr) is called before  XkbFreeNames(kbdDescr, XkbSymbolsNameMask, true). As you can see, it should be called after that, since XkbFreeNames still uses kbdDescr.