### PR TITLE
Update visibility for client/host mode checkbox during settings loading.

### DIFF
--- a/src/gui/src/SettingsDialog.cpp
+++ b/src/gui/src/SettingsDialog.cpp
@@ -53,11 +53,8 @@ SettingsDialog::SettingsDialog(QWidget* parent, AppConfig& config) :
     buttonBox->button(QDialogButtonBox::Save)->setEnabled(false);
     enableControls(appConfig().isWritable());
 
-    const auto isClientMode = m_pMainWindow->synergyType() == MainWindow::synergyClient;
-    m_pCheckBoxLanguageSync->setVisible(isClientMode);
-    m_pCheckBoxScrollDirection->setVisible(isClientMode);
-    m_pCheckBoxClientHostMode->setVisible(isClientMode && appConfig().getInitiateConnectionFromServer());
-    m_pCheckBoxServerClientMode->setVisible(!isClientMode && appConfig().getInitiateConnectionFromServer());
+    m_pCheckBoxLanguageSync->setVisible(isClientMode());
+    m_pCheckBoxScrollDirection->setVisible(isClientMode());
 
     const auto& serveConfig = m_pMainWindow->serverConfig();
     m_pLineEditScreenName->setValidator(new validators::ScreenNameValidator(m_pLineEditScreenName, m_pLabelNameError, (&serveConfig.screens())));
@@ -198,6 +195,8 @@ void SettingsDialog::loadFromConfig() {
     m_pLabelInstallBonjour->hide();
 #endif
 
+    m_pCheckBoxClientHostMode->setVisible(isClientMode() && appConfig().getInitiateConnectionFromServer());
+    m_pCheckBoxServerClientMode->setVisible(!isClientMode() && appConfig().getInitiateConnectionFromServer());
 }
 
 void SettingsDialog::setupSeurity()
@@ -219,6 +218,11 @@ void SettingsDialog::setupSeurity()
         m_pPushButtonBrowseCert->hide();
         m_pPushButtonRegenCert->hide();
     }
+}
+
+bool SettingsDialog::isClientMode() const
+{
+    return (m_pMainWindow->synergyType() == MainWindow::synergyClient);
 }
 
 void SettingsDialog::allowAutoConfig()

--- a/src/gui/src/SettingsDialog.h
+++ b/src/gui/src/SettingsDialog.h
@@ -67,6 +67,9 @@ class SettingsDialog : public QDialog, public Ui::SettingsDialogBase
         /// @brief This method setups security section in setting
         void setupSeurity();
 
+        /// @brief Returns true if current mode is a client mode
+        bool isClientMode() const;
+
     private:
         MainWindow* m_pMainWindow;
         AppConfig& m_appConfig;


### PR DESCRIPTION
SYNERGY1-1616
This PR updates fixes problem with client/host mode checkbox when user switches between settings scope