### PR TITLE
Use default value for 'Initiate connection from server'

### DIFF
--- a/src/gui/src/AppConfig.cpp
+++ b/src/gui/src/AppConfig.cpp
@@ -577,16 +577,22 @@ QVariant AppConfig::loadCommonSetting(AppConfig::Setting name, const QVariant& d
     return result;
 }
 
-void AppConfig::loadScope(ConfigWriter::Scope scope) const {
+void AppConfig::loadScope(ConfigWriter::Scope scope) {
    auto writer = ConfigWriter::make();
 
    if (writer->getScope() != scope) {
+      setDefaultValues();
       writer->setScope(scope);
       if (writer->hasSetting(settingName(kScreenName), writer->getScope())) {
           //If the user already has settings, then load them up now.
           writer->globalLoad();
       }
    }
+}
+
+void AppConfig::setDefaultValues()
+{
+    m_InitiateConnectionFromServer = false;
 }
 
 void AppConfig::setLoadFromSystemScope(bool value) {

--- a/src/gui/src/AppConfig.h
+++ b/src/gui/src/AppConfig.h
@@ -344,7 +344,11 @@ protected:
 
         /// @brief This method loads config from specified scope
         /// @param [in] scope which should be loaded.
-        void loadScope(GUI::Config::ConfigWriter::Scope scope) const;
+        void loadScope(GUI::Config::ConfigWriter::Scope scope);
+
+        /// @brief This function sets default values
+        /// for settings that shouldn't be copied from between scopes.
+        void setDefaultValues();
 
     signals:
         void sslToggled() const;


### PR DESCRIPTION
During switching between settings scopes (user and system), this sets the default value for the hidden option `InitiateConnectionFromServer`.

SYNERGY1-1616
