### PR TITLE
synergy-core: add missing <cstdint> includes for SIZE_MAX

### DIFF
--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -23,10 +23,11 @@
 #include "base/log_outputters.h"
 #include "common/Version.h"
 
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <iostream>
-#include <ctime> 
+#include <ctime>
 
 // names of priorities
 static const char*        g_priority[] = {

--- a/src/lib/base/String.cpp
+++ b/src/lib/base/String.cpp
@@ -21,6 +21,7 @@
 #include "common/stdvector.h"
 
 #include <cctype>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/src/lib/synergy/IKeyState.cpp
+++ b/src/lib/synergy/IKeyState.cpp
@@ -19,6 +19,7 @@
 #include "synergy/IKeyState.h"
 #include "base/EventQueue.h"
 
+#include <cstdint>
 #include <cstring>
 #include <cstdlib>
 


### PR DESCRIPTION
Without the change the build on upcoming `gcc-13` ails as:

    src/lib/base/Log.cpp: In member function 'void Log::print(const char*, int, const char*, ...)':
    src/lib/base/Log.cpp:128:23:
      error: 'SIZE_MAX' was not declared in this scope
      128 |     if ((strnlen(fmt, SIZE_MAX) > 2) && (fmt[0] == '%' && fmt[1] == 'z')) {
          |                       ^~~~~~~~
    src/lib/base/Log.cpp:30:1:
      note: 'SIZE_MAX' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
       29 | #include <ctime>
      +++ |+#include <cstdint>
       30 |

gcc-13 cleaned it's header dependencies and that exposes these failures.