### PR TITLE
Upgrade the default hashing algorithm

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 
 Bug fixes:
 - #7208 Fix crash on FreeBSD when pressing special keys on a client.
+- #7241 Change the default signature hashing algorithm for sha256.
 
 Enhancements:
 - #7222 Ability to initiate non-TLS connection from server

--- a/res/openssl/synergy.conf
+++ b/res/openssl/synergy.conf
@@ -15,7 +15,7 @@ new_certs_dir = $dir/certs
 certificate = $dir/cacert.pem
 private_key = $dir/private/cakey.pem
 default_days = 365
-default_md = md5
+default_md = sha256
 preserve = no
 email_in_dn = no
 nameopt = default_ca
@@ -33,7 +33,7 @@ emailAddress = optional
 [req]
 default_bits = 1024 # Size of keys
 default_keyfile = key.pem # name of generated keys
-default_md = md5 # message digest algorithm
+default_md = sha256 # message digest algorithm
 string_mask = nombstr # permitted characters
 distinguished_name = req_distinguished_name
 req_extensions = v3_req


### PR DESCRIPTION
[SYNERGY1-1634](https://symless.atlassian.net/browse/SYNERGY1-1634)

Upgrade the default hashing algorithm for message digests from md5 to sha256.