### PR TITLE
Build unified core or separate server and client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,12 @@ else()
     option (ENABLE_COVERAGE "Build with coverage")
 endif()
 
+if (DEFINED ENV{SYNERGY_UNIFIED_CORE})
+    option (UNIFIED_CORE "Build a single core binary" ON)
+else()
+    option (UNIFIED_CORE "Build a single core binary" OFF)
+endif()
+
 if ($ENV{SYNERGY_ENTERPRISE})
     option (SYNERGY_ENTERPRISE "Build Enterprise" ON)
 else()

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ Enhancements:
 - #7254 Ability to bind client to a network interface
 - #7263 Change name of Flatpak uploaded to snapshots
 - #7269 Reword file drag drop error to debug message
+- #7274 Only build necessary binaries
 
 1.14.6
 ======

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -15,7 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 add_subdirectory(synergyd)
-add_subdirectory(synergyc)
-add_subdirectory(synergys)
+if (UNIFIED_CORE)
+    add_subdirectory(synergy-core)
+else()
+    add_subdirectory(synergyc)
+    add_subdirectory(synergys)
+endif (UNIFIED_CORE)
 add_subdirectory(syntool)
-add_subdirectory(synergy-core)


### PR DESCRIPTION
When building Synergy, we should only need to build a single `synergy-core` binary or separate `synergys` and `synergyc` binaries.