### PR TITLE
Catch standard exceptions on unexpected exit

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ Enhancements:
 - #7269 Change file drag drop ERROR to DEBUG message
 - #7274 Support env var to build unified core binary
 - #7277 Change all errors that cause crash are FATAL
+- #7282 Improve error handling for thread jobs
 - #7284 Change session ID info log message to DEBUG2
 
 CI changes:

--- a/src/lib/mt/Thread.cpp
+++ b/src/lib/mt/Thread.cpp
@@ -23,6 +23,7 @@
 #include "arch/Arch.h"
 #include "base/Log.h"
 #include "base/IJob.h"
+#include <exception>
 
 //
 // Thread
@@ -169,12 +170,17 @@ Thread::threadFunc(void* vjob)
         LOG((CLOG_DEBUG1 "caught exit on thread 0x%08x, result %p", id, result));
     }
     catch (XBase& e) {
-        LOG((CLOG_ERR "exception on thread 0x%08x: %s", id, e.what()));
+        LOG((CLOG_ERR "synergy exception on thread 0x%08x: %s", id, e.what()));
+        delete job;
+        throw;
+    }
+    catch (std::exception& e) {
+        LOG((CLOG_ERR "standard exception on thread 0x%08x: %s", id, e.what()));
         delete job;
         throw;
     }
     catch (...) {
-        LOG((CLOG_ERR "exception on thread 0x%08x: <unknown>", id));
+        LOG((CLOG_ERR "non-exception throw on thread 0x%08x: <unknown>", id));
         delete job;
         throw;
     }


### PR DESCRIPTION
[S3-1369](https://symless.atlassian.net/browse/S3-1369)

We seem to be reporting system errors as <unknown>.
This splits out exception throws and non-exception throws.

[S3-1369]: https://symless.atlassian.net/browse/S3-1369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ