### PR TITLE
 Restore lpDesktop assignment in Windows daemon

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,5 @@
 # 1.15.0
 
-Bug fixes:
-
-- #7326 Restore lpDesktop assignment in Windows daemon
-
 Enhancements:
 
 - #7254 Bind client to a network interface with --address
@@ -16,7 +12,7 @@ Enhancements:
 - #7282 Improve error handling for thread jobs
 - #7284 Change session ID info log message to DEBUG2
 
-Build/CI:
+Tasks:
 
 - #7283 Update all workflows and fix broken macOS workflows
 - #7313 Fix CodeQL workflow: Failed to perl 404 Not Found
@@ -28,6 +24,7 @@ Build/CI:
 - #7322 Use C++20 and add Windows CMake preset
 - #7323 Add Linux and macOS CMake presets
 - #7325 Add timeout to all GitHub workflows
+- #7326 Restore lpDesktop assignment in Windows daemon
 
 # 1.14.6
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 # 1.15.0
 
+Bug fixes:
+
+- #7326 Restore lpDesktop assignment in Windows daemon
+
 Enhancements:
 
 - #7254 Bind client to a network interface with --address

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -398,12 +398,12 @@ MSWindowsWatchdog::startProcess()
 void
 MSWindowsWatchdog::setStartupInfo(STARTUPINFO& si)
 {
-	// TODO: maybe this should be \winlogon if we have logonui.exe?
-	char desktop[] = "winsta0\\Default";
-
 	ZeroMemory(&si, sizeof(STARTUPINFO));
 	si.cb = sizeof(STARTUPINFO);
-	si.lpDesktop = desktop;
+    
+	// TODO: maybe this should be \winlogon if we have logonui.exe?
+	si.lpDesktop = (LPSTR)"winsta0\\Default";
+
 	si.hStdError = m_stdOutWrite;
 	si.hStdOutput = m_stdOutWrite;
 	si.dwFlags |= STARTF_USESTDHANDLES;

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -40,6 +40,9 @@
 #define CURRENT_PROCESS_ID 0
 #define MAXIMUM_WAIT_TIME 3
 
+// TODO: maybe this should be \winlogon if we have logonui.exe?
+static char g_desktopName[] = "winsta0\\Default";
+
 namespace {
 std::string
 trimDesktopName(const std::string& nameFromTraces)
@@ -400,10 +403,7 @@ MSWindowsWatchdog::setStartupInfo(STARTUPINFO& si)
 {
 	ZeroMemory(&si, sizeof(STARTUPINFO));
 	si.cb = sizeof(STARTUPINFO);
-    
-	// TODO: maybe this should be \winlogon if we have logonui.exe?
-	si.lpDesktop = (LPSTR)"winsta0\\Default";
-
+	si.lpDesktop = g_desktopName;
 	si.hStdError = m_stdOutWrite;
 	si.hStdOutput = m_stdOutWrite;
 	si.dwFlags |= STARTF_USESTDHANDLES;


### PR DESCRIPTION
In an attempt to fix a C++20 compile issue, `si.lpDesktop` (`src\lib\platform\MSWindowsWatchdog.cpp`) was assigned to a string buffer, but since this was on the stack, it'll have been deleted before Win32 could access it.

Compile error:
`error C2440: '=': cannot convert from 'const char [16]' to 'LPSTR'`

Related warning:
`ISO C++11 does not allow conversion from string literal to 'LPSTR' (aka 'char *')`

Error from Windows Daemon:
```
[2024-01-12T19:48:11] FATAL: failed to launch, error: process immediately stopped
	C:\Projects\symless\synergy-3.1\ext\synergy-core\src\lib\platform\MSWindowsWatchdog.cpp,290
```

Since `lpDesktop` wants a mutable char buffer, I'll use a heap char buffer (rather than casting to `LPSTR` as was done previously).

S3-2008