### PR TITLE
Only use Ninja to build on Windows

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,7 +5,6 @@
       "name": "base",
       "hidden": true,
       "binaryDir": "${sourceDir}/build",
-      "generator": "Ninja",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
@@ -15,6 +14,7 @@
       "name": "windows",
       "displayName": "Windows",
       "inherits": "base",
+      "generator": "Ninja",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "cl.exe",
         "CMAKE_CXX_COMPILER": "cl.exe"
@@ -31,12 +31,14 @@
     {
       "name": "linux",
       "displayName": "Linux",
-      "inherits": "base"
+      "inherits": "base",
+      "generator": "Ninja"
     },
     {
       "name": "macos",
       "displayName": "macOS",
-      "inherits": "base"
+      "inherits": "base",
+      "generator": "Unix Makefiles"
     }
   ],
   "buildPresets": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,7 +32,7 @@
       "name": "linux",
       "displayName": "Linux",
       "inherits": "base",
-      "generator": "Ninja"
+      "generator": "Unix Makefiles"
     },
     {
       "name": "macos",

--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,7 @@ Tasks:
 - #7323 Add Linux and macOS CMake presets
 - #7325 Add timeout to all GitHub workflows
 - #7326 Restore lpDesktop assignment in Windows daemon
+- #7327 Only use Ninja to build on Windows
 
 # 1.14.6
 


### PR DESCRIPTION
Ninja brings significant benefits to building on Windows, but we don't need it for macOS and Linux right now (so we can stick with make).

S3-1978