### PR TITLE
Reset error state before calling Process32Next

### DIFF
--- a/.github/workflows/job-test-windows.yml
+++ b/.github/workflows/job-test-windows.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   test-windows:
     runs-on: windows-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     env:
       GIT_COMMIT: ${{ github.sha }}

--- a/.github/workflows/job-test-windows.yml
+++ b/.github/workflows/job-test-windows.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   test-windows:
     runs-on: windows-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     env:
       GIT_COMMIT: ${{ github.sha }}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,8 @@
     {
       "label": "reinstall windows daemon",
       "type": "shell",
-      "command": "python scripts/windows_daemon.py"
+      "command": "python scripts/windows_daemon.py",
+      "presentation": { "close": true }
     }
   ]
 }

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,7 +12,7 @@ Enhancements:
 - #7282 Improve error handling for thread jobs
 - #7284 Change session ID info log message to DEBUG2
 
-Build/CI:
+Tasks:
 
 - #7283 Update all workflows and fix broken macOS workflows
 - #7313 Fix CodeQL workflow: Failed to perl 404 Not Found
@@ -24,6 +24,7 @@ Build/CI:
 - #7322 Use C++20 and add Windows CMake preset
 - #7323 Add Linux and macOS CMake presets
 - #7325 Add timeout to all GitHub workflows
+- #7326 Restore lpDesktop assignment in Windows daemon
 
 # 1.14.6
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,7 @@ Tasks:
 - #7325 Add timeout to all GitHub workflows
 - #7326 Restore lpDesktop assignment in Windows daemon
 - #7327 Only use Ninja to build on Windows
+- #7328 Reset error state before calling Process32Next
 
 # 1.14.6
 

--- a/scripts/windows_daemon.py
+++ b/scripts/windows_daemon.py
@@ -5,35 +5,39 @@ import sys
 import argparse
 import glob
 
-BIN_FILE_BASE = 'synergyd'
+BIN_NAME = 'synergyd'
 SOURCE_BIN_DIR = os.path.join('build', 'bin')
-SOURCE_BIN_GLOB = f'{BIN_FILE_BASE}*'
 TARGET_BIN_DIR = 'bin'
-TARGET_BIN_FILE = f'{os.path.join(TARGET_BIN_DIR, BIN_FILE_BASE)}.exe'
 SERVICE_NOT_RUNNING_ERROR = 2
 
 def main():
   """Entry point for the script."""
 
   parser = argparse.ArgumentParser()
-  parser.add_argument('-p', action='store_true')
+  parser.add_argument('--pause-on-exit', action='store_true')
+  parser.add_argument('--source-bin-dir', default=SOURCE_BIN_DIR)
+  parser.add_argument('--target-bin-dir', default=TARGET_BIN_DIR)
+  parser.add_argument('--source-bin-name', default=BIN_NAME)
+  parser.add_argument('--target-bin-name', default=BIN_NAME)
   args = parser.parse_args()
-
-  try:
-    reinstall()
-  except Exception as e:
-    print(f'Error: {e}')
-  
-  if (args.p):
-    input('Press any key to continue...')
-
-def reinstall():
-  """Stops the running daemon service, copies files, and reinstalls."""
 
   if not is_admin():
     print('Re-launching script as admin')
-    ctypes.windll.shell32.ShellExecuteW(None, 'runas', sys.executable, f'{__file__} -p', None, 1)
+    args = ' '.join(sys.argv[1:])
+    command = f'{__file__} --pause-on-exit {args}'
+    ctypes.windll.shell32.ShellExecuteW(None, 'runas', sys.executable, command, None, 1)
     sys.exit()
+
+  try:
+    reinstall(args.source_bin_dir, args.target_bin_dir, args.source_bin_name, args.target_bin_name)
+  except Exception as e:
+    print(f'Error: {e}')
+  
+  if (args.pause_on_exit):
+    input('Press any key to continue...')
+
+def reinstall(source_bin_dir, target_bin_dir, source_bin_name, target_bin_name):
+  """Stops the running daemon service, copies files, and reinstalls."""
   
   print('Stopping daemon service')
   try:
@@ -44,24 +48,40 @@ def reinstall():
     else:
       raise e
 
-  print(f'Persisting dir: {TARGET_BIN_DIR}')
-  os.makedirs(TARGET_BIN_DIR, exist_ok=True)
+  copy_bin_files(source_bin_dir, target_bin_dir, source_bin_name, target_bin_name)
 
-  source_files = glob.glob(os.path.join(SOURCE_BIN_DIR, SOURCE_BIN_GLOB))
+  target_bin_file = f'{os.path.join(target_bin_dir, target_bin_name)}.exe'
+
+  print('Removing old daemon service')
+  subprocess.run([target_bin_file, '/uninstall'], shell=True, check=True)
+
+  print('Installing daemon service')
+  subprocess.run([target_bin_file, '/install'], shell=True, check=True)
+
+def copy_bin_files(source_bin_dir, target_bin_dir, source_bin_name, target_bin_name):
+
+  if not os.path.isdir(source_bin_dir):
+    raise Exception(f'Invalid source bin dir: {source_bin_dir}')
+
+  print(f'Persisting dir: {target_bin_dir}')
+  os.makedirs(target_bin_dir, exist_ok=True)
+
+  source_bin_glob = f'{source_bin_name}*'
+  source_files = glob.glob(os.path.join(source_bin_dir, source_bin_glob))
+
+  if not source_files:
+    raise Exception(f'No files found in {source_bin_dir} matching {source_bin_glob}')
+
   for source_file in source_files:
-    target_file = os.path.join(TARGET_BIN_DIR, os.path.basename(source_file))
+    base_name = os.path.basename(source_file)
+    base_name = base_name.replace(source_bin_name, target_bin_name)
+    target_file = os.path.join(target_bin_dir, base_name)
     print(f'Copying {source_file} to {target_file}')
-    # use the copy command; shutil.copy gives us a permission denied error.
+  # use the copy command; shutil.copy gives us a permission denied error.
     try:
       subprocess.run(['copy', source_file, target_file], shell=True, check=True)
     except subprocess.CalledProcessError as e:
       print(f'Copy failed: {e}')
-  
-  print('Removing old daemon service')
-  subprocess.run([TARGET_BIN_FILE, '/uninstall'], shell=True, check=True)
-
-  print('Installing daemon service')
-  subprocess.run([TARGET_BIN_FILE, '/install'], shell=True, check=True)
 
 def is_admin():
     """Returns True if the current process has admin privileges."""

--- a/scripts/windows_daemon.py
+++ b/scripts/windows_daemon.py
@@ -28,7 +28,7 @@ def main():
 def reinstall():
   if not is_admin():
     print('Re-launching script as admin')
-    ctypes.windll.shell32.ShellExecuteW(None, 'runas', sys.executable, __file__, None, 1)
+    ctypes.windll.shell32.ShellExecuteW(None, 'runas', sys.executable, __file__ + ' -p', None, 1)
     sys.exit()
   
   print('Stopping daemon service')

--- a/scripts/windows_daemon.py
+++ b/scripts/windows_daemon.py
@@ -34,7 +34,7 @@ def main():
     print(f'Error: {e}')
   
   if (args.pause_on_exit):
-    input('Press any key to continue...')
+    input('Press enter to continue...')
 
 def reinstall(source_bin_dir, target_bin_dir, source_bin_name, target_bin_name):
   """Stops the running daemon service, copies files, and reinstalls."""

--- a/scripts/windows_daemon.py
+++ b/scripts/windows_daemon.py
@@ -1,0 +1,65 @@
+import os
+import subprocess
+import ctypes
+import sys
+import argparse
+import glob
+
+bin_file_base = 'synergyd'
+source_bin_dir = os.path.join('build', 'bin')
+source_bin_file_glob = bin_file_base + '*'
+target_bin_dir = 'bin'
+target_bin_file = os.path.join(target_bin_dir, bin_file_base) + '.exe'
+service_not_running_error = 2
+
+def main():  
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-p', action='store_true')
+  args = parser.parse_args()
+
+  try:
+    reinstall()
+  except Exception as e:
+    print('Error: ' + str(e))
+  
+  if (args.p):
+    input('Press any key to continue...')
+
+def reinstall():
+  if not is_admin():
+    print('Re-launching script as admin')
+    ctypes.windll.shell32.ShellExecuteW(None, 'runas', sys.executable, __file__, None, 1)
+    sys.exit()
+  
+  print('Stopping daemon service')
+  try:
+    subprocess.run(['net', 'stop', 'synergy'], shell=True, check=True)
+  except subprocess.CalledProcessError as e:
+    if (e.returncode == service_not_running_error):
+      print('Daemon service not running')
+    else:
+      raise e
+
+  print('Persisting dir: ' + target_bin_dir)
+  os.makedirs(target_bin_dir, exist_ok=True)
+
+  source_files = glob.glob(os.path.join(source_bin_dir, source_bin_file_glob))
+  for source_file in source_files:
+    target_file = os.path.join(target_bin_dir, os.path.basename(source_file))
+    print('Copying ' + source_file + ' to ' + target_file)
+    # use the copy command; shutil.copy gives us a permission denied error.
+    subprocess.run(['copy', source_file, target_file], shell=True, check=True)
+  
+  print('Removing old daemon service')
+  subprocess.run([target_bin_file, '/uninstall'], shell=True, check=True)
+
+  print('Installing daemon service')
+  subprocess.run([target_bin_file, '/install'], shell=True, check=True)
+
+def is_admin():
+    try:
+        return ctypes.windll.shell32.IsUserAnAdmin()
+    except ctypes.WinError:
+        return False
+
+main()

--- a/src/lib/platform/MSWindowsSession.cpp
+++ b/src/lib/platform/MSWindowsSession.cpp
@@ -158,13 +158,20 @@ MSWindowsSession::updateActiveSession()
 BOOL
 MSWindowsSession::nextProcessEntry(HANDLE snapshot, LPPROCESSENTRY32 entry)
 {
+    // TODO: issue S3-2021
+    // resetting the error state here is acceptable, but having to do so indicates that a
+    // different win32 function call has failed beforehand. we should always check for errors 
+    // after each win32 function call.
+    SetLastError(0);
+
     BOOL gotEntry = Process32Next(snapshot, entry);
     if (!gotEntry) {
 
         DWORD err = GetLastError();
-        if (err != ERROR_NO_MORE_FILES) {
 
-            // only worry about error if it's not the end of the snapshot
+        // only throw if it's not the end of the snapshot, if not the 'no more files' error
+        // then it's probably something serious.
+        if (err != ERROR_NO_MORE_FILES) {
             LOG((CLOG_ERR "could not get next process entry"));
             throw XArch(new XArchEvalWindows());
         }

--- a/src/lib/platform/MSWindowsWatchdog.cpp
+++ b/src/lib/platform/MSWindowsWatchdog.cpp
@@ -40,6 +40,9 @@
 #define CURRENT_PROCESS_ID 0
 #define MAXIMUM_WAIT_TIME 3
 
+// TODO: maybe this should be \winlogon if we have logonui.exe?
+static char g_desktopName[] = "winsta0\\Default";
+
 namespace {
 std::string
 trimDesktopName(const std::string& nameFromTraces)
@@ -398,12 +401,9 @@ MSWindowsWatchdog::startProcess()
 void
 MSWindowsWatchdog::setStartupInfo(STARTUPINFO& si)
 {
-	// TODO: maybe this should be \winlogon if we have logonui.exe?
-	char desktop[] = "winsta0\\Default";
-
 	ZeroMemory(&si, sizeof(STARTUPINFO));
 	si.cb = sizeof(STARTUPINFO);
-	si.lpDesktop = desktop;
+	si.lpDesktop = g_desktopName;
 	si.hStdError = m_stdOutWrite;
 	si.hStdOutput = m_stdOutWrite;
 	si.dwFlags |= STARTF_USESTDHANDLES;


### PR DESCRIPTION
In the Windows daemon. after calling `Process32Next`, the `GetLastError` function can intermittently return `ERROR_FILE_EXISTS` (`Cannot create a file when that file already exists`) which doesn't make sense in the context of `Process32Next`; this function should not normally return that error code. This suggests that some other earlier Win32 function call is failing and setting the error state.

For now, we'll call `SetLastError(0)` to reset the error state before calling `Process32Next`.

This PR also adds a new script, `scripts\windows_daemon.py` which makes it easier to install the Windows daemon from the `build/bin` dir (to save us from fiddling around with commands).

To test: Difficult to reproduce as it's intermittent (perhaps a memory error). If you build the daemon, install it (using the new `.py` script) and are able to launch the Core, then it should be good to go.

S3-2016
S3-2021