### PR TITLE
Split CMake presets into debug and release

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -6,14 +6,13 @@
       "hidden": true,
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     },
     {
       "name": "windows",
-      "displayName": "Windows",
       "inherits": "base",
+      "hidden": true,
       "generator": "Ninja",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "cl.exe",
@@ -30,32 +29,83 @@
     },
     {
       "name": "linux",
-      "displayName": "Linux",
+      "hidden": true,
       "inherits": "base",
       "generator": "Unix Makefiles"
     },
     {
       "name": "macos",
-      "displayName": "macOS",
+      "hidden": true,
       "inherits": "base",
       "generator": "Unix Makefiles"
+    },
+    {
+      "name": "windows-debug",
+      "inherits": "windows",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "windows-release",
+      "inherits": "windows",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "linux-debug",
+      "inherits": "linux",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "linux-release",
+      "inherits": "linux",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "macos-debug",
+      "inherits": "macos",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "macos-release",
+      "inherits": "macos",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
     }
   ],
   "buildPresets": [
     {
-      "name": "windows",
-      "displayName": "Windows",
-      "configurePreset": "windows"
+      "name": "windows-debug",
+      "configurePreset": "windows-debug"
     },
     {
-      "name": "linux",
-      "displayName": "Linux",
-      "configurePreset": "linux"
+      "name": "windows-release",
+      "configurePreset": "windows-release"
     },
     {
-      "name": "macos",
-      "displayName": "macOS",
-      "configurePreset": "macos"
+      "name": "linux-debug",
+      "configurePreset": "linux-debug"
+    },
+    {
+      "name": "linux-release",
+      "configurePreset": "linux-release"
+    },
+    {
+      "name": "macos-debug",
+      "configurePreset": "macos-debug"
+    },
+    {
+      "name": "macos-release",
+      "configurePreset": "macos-release"
     }
   ]
 }

--- a/ChangeLog
+++ b/ChangeLog
@@ -27,6 +27,7 @@ Tasks:
 - #7326 Restore lpDesktop assignment in Windows daemon
 - #7327 Only use Ninja to build on Windows
 - #7328 Reset error state before calling Process32Next
+- #1177 Split CMake presets into debug and release
 
 # 1.14.6
 


### PR DESCRIPTION
This splits the existing CMake presets `windows`, `macos`, and `linux` into:
- `windows-debug`
- `windows-release`
- `macos-debug`
- `macos-release`
- `linux-debug`
- `linux-release`

S3-2041