### PR TITLE
Update VS Code config for Windows daemon debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,10 +2,31 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "gui",
+      "name": "gui lldb",
       "type": "lldb",
       "request": "launch",
       "program": "${workspaceFolder}/build/bin/synergy",
+      "preLaunchTask": "build"
+    },
+    {
+      "name": "windows daemon attach",
+      "type": "cppvsdbg",
+      "request": "attach",
+      "processId": "${command:pickProcess}"
+    },
+    {
+      "name": "windows daemon attach lldb",
+      "type": "lldb",
+      "request": "attach",
+      "program": "${workspaceFolder}/build/bin/synergyd"
+    },
+    {
+      "name": "windows daemon launch",
+      "type": "cppvsdbg",
+      "cwd": "${workspaceRoot}/build/bin",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/bin/synergyd",
+      "args": ["-f"],
       "preLaunchTask": "build"
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,7 +13,7 @@
       "label": "reinstall windows daemon",
       "type": "shell",
       "command": "python scripts/windows_daemon.py",
-      "presentation": { "close": true }
+      "dependsOn": ["build"]
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,6 +10,13 @@
       }
     },
     {
+      "name": "minimal",
+      "hidden": true,
+      "environment": {
+        "SYNERGY_NO_LEGACY": "ON"
+      }
+    },
+    {
       "name": "windows",
       "inherits": "base",
       "hidden": true,
@@ -83,32 +90,48 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       }
-    }
-  ],
-  "buildPresets": [
-    {
-      "name": "windows-debug",
-      "configurePreset": "windows-debug"
     },
     {
-      "name": "windows-release",
-      "configurePreset": "windows-release"
+      "name": "windows-debug-min",
+      "inherits": ["windows", "minimal"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
     },
     {
-      "name": "linux-debug",
-      "configurePreset": "linux-debug"
+      "name": "windows-release-min",
+      "inherits": ["windows", "minimal"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
     },
     {
-      "name": "linux-release",
-      "configurePreset": "linux-release"
+      "name": "linux-debug-min",
+      "inherits": ["linux", "minimal"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
     },
     {
-      "name": "macos-debug",
-      "configurePreset": "macos-debug"
+      "name": "linux-release-min",
+      "inherits": ["linux", "minimal"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
     },
     {
-      "name": "macos-release",
-      "configurePreset": "macos-release"
+      "name": "macos-debug-min",
+      "inherits": ["macos", "minimal"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "macos-release-min",
+      "inherits": ["macos", "minimal"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
     }
   ]
 }

--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,7 @@ Tasks:
 - #1177 Split CMake presets into debug and release
 - #7331 Script to install deps (Windows only for now)
 - #7332 Static link OpenSSL libs in CMake preset for Windows
+- #7333 Update VS Code config for Windows daemon debugging
 
 # 1.14.6
 


### PR DESCRIPTION
Debugging the Windows Daemon is possible with `cppvsdbg` modes, `attach` and `launch` (when run with `-f` or `/f`). This PR surfaces this knowledge to make it easier for others to debug the Windows Daemon.