### PR TITLE
Clickable debug source paths and new launch target

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,19 +9,19 @@
       "preLaunchTask": "build"
     },
     {
-      "name": "windows daemon attach",
+      "name": "win daemon attach",
       "type": "cppvsdbg",
       "request": "attach",
       "processId": "${command:pickProcess}"
     },
     {
-      "name": "windows daemon attach lldb",
+      "name": "win daemon attach - lldb",
       "type": "lldb",
       "request": "attach",
       "program": "${workspaceFolder}/build/bin/synergyd"
     },
     {
-      "name": "windows daemon launch",
+      "name": "win daemon launch",
       "type": "cppvsdbg",
       "cwd": "${workspaceRoot}/build/bin",
       "request": "launch",
@@ -30,7 +30,7 @@
       "internalConsoleOptions": "openOnSessionStart"
     },
     {
-      "name": "windows daemon launch (rebuild)",
+      "name": "win daemon launch - rebuild",
       "type": "cppvsdbg",
       "cwd": "${workspaceRoot}/build/bin",
       "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,15 @@
       "request": "launch",
       "program": "${workspaceFolder}/build/bin/synergyd",
       "args": ["-f"],
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
+      "name": "windows daemon launch (rebuild)",
+      "type": "cppvsdbg",
+      "cwd": "${workspaceRoot}/build/bin",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/bin/synergyd",
+      "args": ["-f"],
       "preLaunchTask": "build"
     }
   ]

--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,7 @@ Enhancements:
 - #7332 Static link OpenSSL libs in CMake preset for Windows
 - #7333 Update VS Code config for Windows daemon debugging
 - #7334 Implement hello back in IPC protocol
+- #7335 Clickable debug source paths and new launch target
 
 # 1.14.6
 

--- a/src/lib/base/Log.cpp
+++ b/src/lib/base/Log.cpp
@@ -203,7 +203,7 @@ Log::print(const char* file, int line, const char* fmt, ...)
         char* message = new char[size];
 
 #ifndef NDEBUG
-        snprintf(message, size, "[%s] %s: %s\n\t%s,%d", timestamp, g_priority[priority], buffer, file, line);
+        snprintf(message, size, "[%s] %s: %s\n\t%s:%d", timestamp, g_priority[priority], buffer, file, line);
 #else
         snprintf(message, size, "[%s] %s: %s", timestamp, g_priority[priority], buffer);
 #endif


### PR DESCRIPTION
This PR changes the debug source paths from: `/path/to/foobar.cpp,123` to `/path/to/foobar.cpp:123`

When compiled in debug mode, source paths are printed for each log line, making it easy to locate the log line in the soruce. However, due to the comma char (`,`) between the path and the line number, IDEs like VS Code won't take you to the line in the source file when you click the path; for the path and line number to be clickable it has to be a colon (`:`) before the line number. Having a clickable path was never considered because back in the early 2000s when this code was introduced; clickable artifacts in terminal output  wasn't yet a common feature.

This PR also changes the `windows daemon launch` VS Code launch target, adding a similar target to rebuild before launching. There are different cases where one is more convenient than the other; sometimes calling build again when restarting the process can be obstructive and sometimes having to manually rebuild is cumbersome.

S3-2089