### PR TITLE
Add C++ and LLDB to VS Code recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,8 @@
   "recommendations": [
     "ms-vscode.cmake-tools",
     "twxs.cmake",
-    "llvm-vs-code-extensions.vscode-clangd"
+    "llvm-vs-code-extensions.vscode-clangd",
+    "ms-vscode.cpptools",
+    "vadimcn.vscode-lldb"
   ]
 }

--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,7 @@ Enhancements:
 - #7333 Update VS Code config for Windows daemon debugging
 - #7334 Implement hello back in IPC protocol
 - #7335 Clickable debug source paths and new launch target
+- #7336 Add C++ and LLDB to VS Code recommendations
 
 # 1.14.6
 


### PR DESCRIPTION
This PR adds recommended extensions for C++ and LLDB which are used to run the targets in `.vscode/launch.json`.