### PR TITLE
Use org token instead of regular token to create releases

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -35,7 +35,7 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ORGANIZATION_TOKEN }}
         with:
           tag_name: ${{ steps.next-version.outputs.next-version }}
           release_name: ${{ steps.next-version.outputs.next-version }}


### PR DESCRIPTION
I believe this solves the problem where:

> GitHub prevents workflows from running on events that were caused by other workflows to prevent unlimited recursion (See the docs: [Triggering a workflow from a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow))