### PR TITLE
Make version check URL v1-specific and configurable

### DIFF
--- a/cmake/Definitions.cmake
+++ b/cmake/Definitions.cmake
@@ -25,6 +25,11 @@ macro(configure_definitions)
   configure_ninja()
   configure_options()
 
+  if(NOT DEFINED VERSION_URL)
+    set(VERSION_URL "https://api.symless.com/version?version=v1")
+  endif()
+  add_definitions(-DSYNERGY_VERSION_URL="${VERSION_URL}")
+
   if(ENABLE_LICENSING)
     message(STATUS "Licensing enabled")
     add_definitions(-DSYNERGY_ENABLE_LICENSING=1)

--- a/src/gui/src/VersionChecker.cpp
+++ b/src/gui/src/VersionChecker.cpp
@@ -24,8 +24,6 @@
 #include <QNetworkRequest>
 #include <QProcess>
 
-#define VERSION_URL "https://api.symless.com/version"
-
 VersionChecker::VersionChecker() {
   m_manager = new QNetworkAccessManager(this);
 
@@ -36,7 +34,7 @@ VersionChecker::VersionChecker() {
 VersionChecker::~VersionChecker() { delete m_manager; }
 
 void VersionChecker::checkLatest() {
-  auto request = QNetworkRequest(QUrl(VERSION_URL));
+  auto request = QNetworkRequest(QUrl(SYNERGY_VERSION_URL));
   request.setHeader(QNetworkRequest::UserAgentHeader,
                     QString("Synergy (") + SYNERGY_VERSION + ") " +
                         QSysInfo::prettyProductName());


### PR DESCRIPTION
https://symless.atlassian.net/browse/S1-1684

To test:
1. Host the version service and set the `version.v1` to `1.100.0-test`
2. Run: `cmake -B build -DVERSION_URL=<dev-version-url>`
3. Build
4. Run the GUI
5. Verify that the update checker reports `1.100.0-test` is available