### PR TITLE
Re-run `macdeployqt6` to copy missing Qt 6 dependencies

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -49,6 +49,7 @@ Enhancements:
 - #7379 Resolve Qt framework path with `install_name_tool`
 - #7380 Add `qt6-qpa-plugins` Qt dependency for Debian
 - #7381 Set macOS min version to macOS 12.0
+- #7382 Re-run `macdeployqt6` to copy missing Qt 6 dependencies
 
 # 1.14.6
 

--- a/scripts/lib/mac.py
+++ b/scripts/lib/mac.py
@@ -1,5 +1,5 @@
 import dmgbuild  # type: ignore
-import os, time, json
+import os, time, json, shutil
 import lib.cmd_utils as cmd_utils
 import lib.env as env
 from lib.certificate import Certificate
@@ -101,17 +101,15 @@ def package_env_vars():
 
 
 def build_bundle():
+    # it's important to build a new bundle every time, so that we catch bugs with fresh builds.
+    if os.path.exists(app_path):
+        print(f"Bundle already exists, deleting: {app_path}")
+        shutil.rmtree(app_path)
+
     print("Building bundle...")
+
     # cmake build install target should run macdeployqt
     cmd_utils.run("cmake --build build --target install", shell=True, print_cmd=True)
-
-    bundle_bin_path = "Contents/MacOS/synergy"
-    cmd_utils.run(
-        'install_name_tool -add_rpath "@executable_path/../Frameworks" '
-        f"{app_path}/{bundle_bin_path}",
-        shell=True,
-        print_cmd=True,
-    )
 
 
 def sign_bundle(codesign_id):

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -55,10 +55,10 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   install(CODE "MESSAGE (\"Running: ${MACDEPLOYQT_CMD}\")")
   install(CODE "execute_process(COMMAND ${MACDEPLOYQT_CMD})")
 
-  # HACK: bundle again to fix missing deps. since qt6, it seems that on the
-  # first pass misses out many dependencies from the Framework dir (it also
-  # finishes quickly with a bunch of warnings), and the 2nd pass (which takes
-  # much longer), all of the dependencies are copied over.
+  # HACK: Bundle again to fix missing deps. Since Qt 6, it seems that the first
+  # pass misses out many dependencies from the Framework dir (it also finishes
+  # quickly with a bunch of warnings), and after the 2nd pass (which takes much
+  # longer), all of the dependencies are copied to the bundle.
   install(CODE "execute_process(COMMAND ${MACDEPLOYQT_CMD})")
 
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -55,6 +55,12 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   install(CODE "MESSAGE (\"Running: ${MACDEPLOYQT_CMD}\")")
   install(CODE "execute_process(COMMAND ${MACDEPLOYQT_CMD})")
 
+  # HACK: bundle again to fix missing deps. since qt6, it seems that on the
+  # first pass misses out many dependencies from the Framework dir (it also
+  # finishes quickly with a bunch of warnings), and the 2nd pass (which takes
+  # much longer), all of the dependencies are copied over.
+  install(CODE "execute_process(COMMAND ${MACDEPLOYQT_CMD})")
+
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
   install(TARGETS synergy DESTINATION bin)


### PR DESCRIPTION
https://symless.atlassian.net/browse/S1-1714

To test:
1. Same as https://github.com/symless/synergy-core/pull/7379
2. ... but actually test the binary: `./build/bundle/Synergy.app/Contents/MacOS/synergy`