### PR TITLE
Show message box explaining why settings are read-only

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -79,6 +79,7 @@ Enhancements:
 - #7434 Show dark logo in dark mode and improve .env loader
 - #7435 Add reset settings menu action and env var
 - #7436 Introduced new env vars for testing
+- #7437 Show message box explaining why settings are read-only
 
 # 1.14.6
 

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -887,9 +887,13 @@ void MainWindow::updateStatus() {
 }
 
 void MainWindow::onCoreProcessStateChanged(CoreProcessState state) {
-  qDebug("core process state changed: %d", static_cast<int>(state));
-
   updateStatus();
+
+  if (state == CoreProcessState::Started) {
+    qDebug("recording that core has started");
+    m_AppConfig.setStartedBefore(true);
+    m_ConfigScopes.save();
+  }
 
   if (state == CoreProcessState::Started ||
       state == CoreProcessState::Starting) {

--- a/src/gui/src/MainWindow.h
+++ b/src/gui/src/MainWindow.h
@@ -176,7 +176,7 @@ private:
   void setupControls();
   void resizeEvent(QResizeEvent *event) override;
   void moveEvent(QMoveEvent *event) override;
-  void showFirstRunMessage();
+  void showFirstConnectedMessage();
   void showDevThanksMessage();
   QString productName() const;
   void updateStatus();

--- a/src/gui/src/MainWindowBase.ui
+++ b/src/gui/src/MainWindowBase.ui
@@ -111,28 +111,42 @@
            <number>15</number>
           </property>
           <item>
-           <layout class="QVBoxLayout" name="verticalLayout_3">
-            <property name="spacing">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QRadioButton" name="m_pRadioGroupServer">
-              <property name="text">
-               <string>Use this computer's keyboard and mouse</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="label">
-              <property name="text">
-               <string>(make this computer the server)</string>
-              </property>
-              <property name="indent">
-               <number>20</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
+           <widget class="QWidget" name="m_pWidgetServerRadio" native="true">
+            <layout class="QVBoxLayout" name="verticalLayout_3">
+             <property name="spacing">
+              <number>0</number>
+             </property>
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QRadioButton" name="m_pRadioGroupServer">
+               <property name="text">
+                <string>Use this computer's keyboard and mouse</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="label">
+               <property name="text">
+                <string>(make this computer the server)</string>
+               </property>
+               <property name="indent">
+                <number>20</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
           </item>
           <item alignment="Qt::AlignTop">
            <widget class="QWidget" name="m_pWidgetServer" native="true">
@@ -153,7 +167,7 @@
               <number>0</number>
              </property>
              <item>
-              <widget class="QWidget" name="m_pWidgetServerInverse" native="true">
+              <widget class="QWidget" name="m_pWidgetServerInput" native="true">
                <layout class="QVBoxLayout" name="m_pLayoutServerInverse">
                 <property name="spacing">
                  <number>15</number>
@@ -279,31 +293,45 @@
            <number>15</number>
           </property>
           <item>
-           <layout class="QVBoxLayout" name="verticalLayout_6">
-            <property name="spacing">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QRadioButton" name="m_pRadioGroupClient">
-              <property name="text">
-               <string>Use another computer’s mouse and keyboard</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="label_2">
-              <property name="text">
-               <string>(make this computer the client)</string>
-              </property>
-              <property name="indent">
-               <number>20</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
+           <widget class="QWidget" name="m_pWidgetClientRadio" native="true">
+            <layout class="QVBoxLayout" name="verticalLayout_6">
+             <property name="spacing">
+              <number>0</number>
+             </property>
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QRadioButton" name="m_pRadioGroupClient">
+               <property name="text">
+                <string>Use another computer’s mouse and keyboard</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_2">
+               <property name="text">
+                <string>(make this computer the client)</string>
+               </property>
+               <property name="indent">
+                <number>20</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
           </item>
           <item alignment="Qt::AlignTop">
-           <widget class="QWidget" name="m_pWidgetClient" native="true">
+           <widget class="QWidget" name="m_pWidgetClientInput" native="true">
             <layout class="QVBoxLayout" name="m_pLayoutClient">
              <property name="spacing">
               <number>15</number>

--- a/src/gui/src/MainWindowBase.ui
+++ b/src/gui/src/MainWindowBase.ui
@@ -110,8 +110,14 @@
           <property name="spacing">
            <number>15</number>
           </property>
-          <item>
+          <item alignment="Qt::AlignTop">
            <widget class="QWidget" name="m_pWidgetServerRadio" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <layout class="QVBoxLayout" name="verticalLayout_3">
              <property name="spacing">
               <number>0</number>
@@ -245,7 +251,7 @@
                <property name="sizeHint" stdset="0">
                 <size>
                  <width>20</width>
-                 <height>10</height>
+                 <height>1</height>
                 </size>
                </property>
               </spacer>
@@ -277,6 +283,19 @@
             </layout>
            </widget>
           </item>
+          <item>
+           <spacer name="verticalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>1</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
          </layout>
         </widget>
        </item>
@@ -292,8 +311,14 @@
           <property name="spacing">
            <number>15</number>
           </property>
-          <item>
+          <item alignment="Qt::AlignTop">
            <widget class="QWidget" name="m_pWidgetClientRadio" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <layout class="QVBoxLayout" name="verticalLayout_6">
              <property name="spacing">
               <number>0</number>
@@ -406,7 +431,7 @@
             <property name="sizeHint" stdset="0">
              <size>
               <width>20</width>
-              <height>10</height>
+              <height>1</height>
              </size>
             </property>
            </spacer>

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -50,8 +50,6 @@ public:
   static void msleep(unsigned long msecs) { QThread::msleep(msecs); }
 };
 
-QString getSystemSettingPath();
-
 #if defined(Q_OS_MAC)
 bool checkMacAssistiveDevices();
 #endif

--- a/src/lib/gui/byte_utils.h
+++ b/src/lib/gui/byte_utils.h
@@ -20,7 +20,7 @@
 #include <QByteArray>
 #include <QDataStream>
 #include <QIODevice>
-#include <qlogging.h>
+#include <QtGlobal>
 
 namespace synergy::gui {
 

--- a/src/lib/gui/config/AppConfig.cpp
+++ b/src/lib/gui/config/AppConfig.cpp
@@ -443,7 +443,7 @@ void AppConfig::persistLogDir() const {
 // Begin getters
 ///////////////////////////////////////////////////////////////////////////////
 
-IConfigScopes &AppConfig::scopes() { return m_Scopes; }
+IConfigScopes &AppConfig::scopes() const { return m_Scopes; }
 
 bool AppConfig::activationHasRun() const { return m_ActivationHasRun; }
 

--- a/src/lib/gui/config/AppConfig.cpp
+++ b/src/lib/gui/config/AppConfig.cpp
@@ -394,6 +394,8 @@ void AppConfig::loadScope(ConfigScopes::Scope scope) {
 
   m_Scopes.setActiveScope(scope);
 
+  qDebug("active scope file path: %s", qPrintable(m_Scopes.activeFilePath()));
+
   // only signal ready if there is at least one setting in the required scope.
   // this prevents the current settings from being set back to default.
   if (m_Scopes.scopeContains(

--- a/src/lib/gui/config/AppConfig.h
+++ b/src/lib/gui/config/AppConfig.h
@@ -189,6 +189,7 @@ public:
   //
   // Setters (overrides)
   //
+  void setStartedBefore(bool b) override;
   void setScreenName(const QString &s) override;
   void setPort(int i) override;
   void setNetworkInterface(const QString &s) override;
@@ -213,7 +214,6 @@ public:
 
   void setActivationHasRun(bool value);
   void setWizardHasRun();
-  void setStartedBefore(bool b);
   void setSerialKey(const QString &serialKey);
   void clearSerialKey();
   void setLicenseNextCheck(unsigned long long);

--- a/src/lib/gui/config/AppConfig.h
+++ b/src/lib/gui/config/AppConfig.h
@@ -126,7 +126,6 @@ public:
       IConfigScopes &scopes,
       std::shared_ptr<Deps> deps = std::make_shared<Deps>());
 
-  IConfigScopes &scopes();
   void determineScope();
 
   /**
@@ -139,6 +138,7 @@ public:
   // Getters (overrides)
   //
 
+  IConfigScopes &scopes() const override;
   ProcessMode processMode() const override;
   ElevateMode elevateMode() const override;
   bool tlsEnabled() const override;
@@ -189,7 +189,7 @@ public:
   //
   // Setters (overrides)
   //
-  void setStartedBefore(bool b) override;
+
   void setScreenName(const QString &s) override;
   void setPort(int i) override;
   void setNetworkInterface(const QString &s) override;
@@ -212,6 +212,7 @@ public:
   // Setters (new methods)
   //
 
+  void setStartedBefore(bool b);
   void setActivationHasRun(bool value);
   void setWizardHasRun();
   void setSerialKey(const QString &serialKey);

--- a/src/lib/gui/config/ConfigScopes.h
+++ b/src/lib/gui/config/ConfigScopes.h
@@ -59,7 +59,7 @@ public:
   Scope activeScope() const override;
   QSettingsProxy &activeSettings() override;
   const QSettingsProxy &activeSettings() const override;
-  QString activeFilePath() const;
+  QString activeFilePath() const override;
 
 signals:
   void ready();

--- a/src/lib/gui/config/IAppConfig.h
+++ b/src/lib/gui/config/IAppConfig.h
@@ -67,6 +67,7 @@ public:
   // Getters
   //
 
+  virtual void setStartedBefore(bool startedBefore) = 0;
   virtual void setLoadFromSystemScope(bool loadFromSystemScope) = 0;
   virtual void setScreenName(const QString &screenName) = 0;
   virtual void setPort(int port) = 0;

--- a/src/lib/gui/config/IAppConfig.h
+++ b/src/lib/gui/config/IAppConfig.h
@@ -19,6 +19,8 @@
 
 #include "ElevateMode.h"
 
+#include "gui/config/IConfigScopes.h"
+
 #include <QString>
 
 namespace synergy::gui {
@@ -26,13 +28,16 @@ namespace synergy::gui {
 enum class ProcessMode { kService, kDesktop };
 
 class IAppConfig {
+  using IConfigScopes = synergy::gui::IConfigScopes;
+
 public:
   virtual ~IAppConfig() = default;
 
   //
-  // Setters
+  // Getters
   //
 
+  virtual IConfigScopes &scopes() const = 0;
   virtual QString tlsCertPath() const = 0;
   virtual int tlsKeyLength() const = 0;
   virtual bool tlsEnabled() const = 0;
@@ -64,10 +69,9 @@ public:
   virtual bool clientGroupChecked() const = 0;
 
   //
-  // Getters
+  // Setters
   //
 
-  virtual void setStartedBefore(bool startedBefore) = 0;
   virtual void setLoadFromSystemScope(bool loadFromSystemScope) = 0;
   virtual void setScreenName(const QString &screenName) = 0;
   virtual void setPort(int port) = 0;

--- a/src/lib/gui/config/IConfigScopes.h
+++ b/src/lib/gui/config/IConfigScopes.h
@@ -38,6 +38,7 @@ public:
   virtual bool isActiveScopeWritable() const = 0;
   virtual QSettingsProxy &activeSettings() = 0;
   virtual const QSettingsProxy &activeSettings() const = 0;
+  virtual QString activeFilePath() const = 0;
 
   /**
    * @brief Signals to listeners that the settings that they should read.

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -22,6 +22,7 @@
 #include "gui/license/license_config.h"
 #include "gui/paths.h"
 #include "tls/TlsUtility.h"
+#include <qlogging.h>
 
 #if defined(Q_OS_MAC)
 #include "OSXHelpers.h"
@@ -59,7 +60,25 @@ QString processModeToString(ProcessMode mode) {
     return "service";
   default:
     qFatal("invalid process mode");
-    return "";
+    abort();
+  }
+}
+
+QString processStateToString(CoreProcess::ProcessState state) {
+  using enum CoreProcess::ProcessState;
+
+  switch (state) {
+  case Starting:
+    return "starting";
+  case Started:
+    return "started";
+  case Stopping:
+    return "stopping";
+  case Stopped:
+    return "stopped";
+  default:
+    qFatal("invalid process state");
+    abort();
   }
 }
 
@@ -139,8 +158,8 @@ QString CoreProcess::Deps::getProfileRoot() const {
 //
 
 CoreProcess::CoreProcess(
-    IAppConfig &appConfig, IServerConfig &serverConfig, const ILicense &license,
-    std::shared_ptr<Deps> deps)
+    const IAppConfig &appConfig, const IServerConfig &serverConfig,
+    const ILicense &license, std::shared_ptr<Deps> deps)
     : m_appConfig(appConfig),
       m_serverConfig(serverConfig),
       m_license(license),
@@ -175,7 +194,9 @@ void CoreProcess::onIpcClientServiceReady() {
     qDebug("service ready, continuing core process stop");
     stop();
   } else {
-    qCritical("service ready, but process state is not starting or stopping");
+    // This may happen when the IPC connection fails and then reconnects.
+    qWarning(
+        "ignoring service ready, process state is not starting or stopping");
   }
 }
 
@@ -644,6 +665,10 @@ void CoreProcess::setProcessState(ProcessState state) {
     return;
   }
 
+  qDebug(
+      "core process state changed: %s -> %s", //
+      qPrintable(processStateToString(m_processState)),
+      qPrintable(processStateToString(state)));
   m_processState = state;
   emit processStateChanged(state);
 }

--- a/src/lib/gui/core/CoreProcess.cpp
+++ b/src/lib/gui/core/CoreProcess.cpp
@@ -22,7 +22,6 @@
 #include "gui/license/license_config.h"
 #include "gui/paths.h"
 #include "tls/TlsUtility.h"
-#include <qlogging.h>
 
 #if defined(Q_OS_MAC)
 #include "OSXHelpers.h"
@@ -36,6 +35,7 @@
 #include <QRegularExpression>
 #include <QStandardPaths>
 #include <QTimer>
+#include <QtGlobal>
 
 using namespace synergy::license;
 using namespace synergy::gui::license;

--- a/src/lib/gui/core/CoreProcess.h
+++ b/src/lib/gui/core/CoreProcess.h
@@ -59,7 +59,7 @@ public:
   enum class ConnectionState { Disconnected, Connecting, Connected, Listening };
 
   explicit CoreProcess(
-      IAppConfig &appConfig, IServerConfig &serverConfig,
+      const IAppConfig &appConfig, const IServerConfig &serverConfig,
       const ILicense &license,
       std::shared_ptr<Deps> deps = std::make_shared<Deps>());
 
@@ -119,8 +119,8 @@ private:
   void checkOSXNotification(const QString &line);
 #endif
 
-  IAppConfig &m_appConfig;
-  IServerConfig &m_serverConfig;
+  const IAppConfig &m_appConfig;
+  const IServerConfig &m_serverConfig;
   const ILicense &m_license;
   std::shared_ptr<Deps> m_pDeps;
   QString m_address;

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -63,11 +63,14 @@ SettingsDialog::SettingsDialog(
   m_pLineEditScreenName->setValidator(new validators::ScreenNameValidator(
       m_pLineEditScreenName, m_pScreenNameError, &serverConfig.screens()));
 
-  connect(this, &SettingsDialog::shown, [this] {
-    if (!m_appConfig.isActiveScopeWritable()) {
-      showReadOnlyMessage();
-    }
-  });
+  connect(
+      this, &SettingsDialog::shown, this,
+      [this] {
+        if (!m_appConfig.isActiveScopeWritable()) {
+          showReadOnlyMessage();
+        }
+      },
+      Qt::QueuedConnection);
 }
 
 //

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -21,6 +21,7 @@
 #include "UpgradeDialog.h"
 #include "gui/core/CoreProcess.h"
 #include "gui/license/license_config.h"
+#include "gui/messages.h"
 #include "gui/tls/TlsCertificate.h"
 #include "gui/tls/TlsUtility.h"
 #include "gui/validators/ScreenNameValidator.h"
@@ -61,6 +62,11 @@ SettingsDialog::SettingsDialog(
   m_pScreenNameError = new validators::ValidationError(this);
   m_pLineEditScreenName->setValidator(new validators::ScreenNameValidator(
       m_pLineEditScreenName, m_pScreenNameError, &serverConfig.screens()));
+
+  if (!m_appConfig.isActiveScopeWritable()) {
+    const auto activeScopeFilename = m_appConfig.scopes().activeFilePath();
+    messages::showReadOnlySettings(this, activeScopeFilename);
+  }
 }
 
 //

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -118,7 +118,7 @@ void SettingsDialog::on_m_pRadioSystemScope_toggled(bool checked) {
   loadFromConfig();
   updateControls();
 
-  if (!m_appConfig.isActiveScopeWritable()) {
+  if (isVisible() && !m_appConfig.isActiveScopeWritable()) {
     showReadOnlyMessage();
   }
 }
@@ -252,6 +252,7 @@ void SettingsDialog::updateTlsControls() {
   const auto tlsEnabled = m_tlsUtility.isAvailableAndEnabled();
   const auto writable = m_appConfig.isActiveScopeWritable();
 
+  m_pCheckBoxEnableTls->setEnabled(writable);
   m_pCheckBoxEnableTls->setChecked(writable && tlsEnabled);
   m_pLineEditTlsCertPath->setText(m_appConfig.tlsCertPath());
 

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -64,8 +64,7 @@ SettingsDialog::SettingsDialog(
       m_pLineEditScreenName, m_pScreenNameError, &serverConfig.screens()));
 
   if (!m_appConfig.isActiveScopeWritable()) {
-    const auto activeScopeFilename = m_appConfig.scopes().activeFilePath();
-    messages::showReadOnlySettings(this, activeScopeFilename);
+    showReadOnlyMessage();
   }
 }
 
@@ -113,6 +112,10 @@ void SettingsDialog::on_m_pRadioSystemScope_toggled(bool checked) {
   m_appConfig.setLoadFromSystemScope(checked);
   loadFromConfig();
   updateControls();
+
+  if (!m_appConfig.isActiveScopeWritable()) {
+    showReadOnlyMessage();
+  }
 }
 
 void SettingsDialog::on_m_pPushButtonTlsCertPath_clicked() {
@@ -152,6 +155,11 @@ void SettingsDialog::on_m_pCheckBoxServiceEnabled_toggled(bool) {
 //
 // End of auto-connect slots
 //
+
+void SettingsDialog::showReadOnlyMessage() {
+  const auto activeScopeFilename = m_appConfig.scopes().activeFilePath();
+  messages::showReadOnlySettings(this, activeScopeFilename);
+}
 
 void SettingsDialog::accept() {
   if (!m_pLineEditScreenName->hasAcceptableInput()) {

--- a/src/lib/gui/dialogs/SettingsDialog.cpp
+++ b/src/lib/gui/dialogs/SettingsDialog.cpp
@@ -63,9 +63,11 @@ SettingsDialog::SettingsDialog(
   m_pLineEditScreenName->setValidator(new validators::ScreenNameValidator(
       m_pLineEditScreenName, m_pScreenNameError, &serverConfig.screens()));
 
-  if (!m_appConfig.isActiveScopeWritable()) {
-    showReadOnlyMessage();
-  }
+  connect(this, &SettingsDialog::shown, [this] {
+    if (!m_appConfig.isActiveScopeWritable()) {
+      showReadOnlyMessage();
+    }
+  });
 }
 
 //
@@ -155,6 +157,11 @@ void SettingsDialog::on_m_pCheckBoxServiceEnabled_toggled(bool) {
 //
 // End of auto-connect slots
 //
+
+void SettingsDialog::showEvent(QShowEvent *event) {
+  QDialog::showEvent(event);
+  emit shown();
+}
 
 void SettingsDialog::showReadOnlyMessage() {
   const auto activeScopeFilename = m_appConfig.scopes().activeFilePath();

--- a/src/lib/gui/dialogs/SettingsDialog.h
+++ b/src/lib/gui/dialogs/SettingsDialog.h
@@ -39,6 +39,7 @@ class SettingsDialog : public QDialog, public Ui::SettingsDialogBase {
   Q_OBJECT
 
 public:
+  void extracted();
   SettingsDialog(
       QWidget *parent, IAppConfig &appConfig, const IServerConfig &serverConfig,
       const License &license, const CoreProcess &coreProcess);
@@ -72,6 +73,7 @@ private:
   bool isClientMode() const;
   void updateTlsControls();
   void updateTlsControlsEnabled();
+  void showReadOnlyMessage();
 
   [[no_unique_address]] CoreTool m_coreTool;
   validators::ValidationError *m_pScreenNameError;

--- a/src/lib/gui/dialogs/SettingsDialog.h
+++ b/src/lib/gui/dialogs/SettingsDialog.h
@@ -44,6 +44,9 @@ public:
       QWidget *parent, IAppConfig &appConfig, const IServerConfig &serverConfig,
       const License &license, const CoreProcess &coreProcess);
 
+signals:
+  void shown();
+
 private slots:
   void on_m_pCheckBoxEnableTls_clicked(bool checked);
   void on_m_pCheckBoxLogToFile_stateChanged(int);
@@ -57,6 +60,11 @@ private slots:
 private:
   void accept() override;
   void reject() override;
+  void showEvent(QShowEvent *event) override;
+  bool isClientMode() const;
+  void updateTlsControls();
+  void updateTlsControlsEnabled();
+  void showReadOnlyMessage();
 
   /// @brief Load all settings.
   void loadFromConfig();
@@ -69,11 +77,6 @@ private:
 
   /// @brief Enables controls when they should be.
   void updateControls();
-
-  bool isClientMode() const;
-  void updateTlsControls();
-  void updateTlsControlsEnabled();
-  void showReadOnlyMessage();
 
   [[no_unique_address]] CoreTool m_coreTool;
   validators::ValidationError *m_pScreenNameError;

--- a/src/lib/gui/ipc/QDataStreamProxy.h
+++ b/src/lib/gui/ipc/QDataStreamProxy.h
@@ -24,24 +24,14 @@ class QDataStreamProxy {
 public:
   explicit QDataStreamProxy() = default;
   explicit QDataStreamProxy(QTcpSocket *socket)
-      : m_Socket(socket),
-        m_Stream(std::make_unique<QDataStream>(socket)) {}
+      : m_Stream(std::make_unique<QDataStream>(socket)) {}
   virtual ~QDataStreamProxy() = default;
 
   virtual qint64 writeRawData(const char *data, int len) {
     assert(m_Stream);
-    assert(m_Socket);
-
-    const auto result = m_Stream->writeRawData(data, len);
-
-    // Causes a small performance hit, but ensures that all bytes are written
-    // when the function returns.
-    m_Socket->flush();
-
-    return result;
+    return m_Stream->writeRawData(data, len);
   }
 
 private:
-  QTcpSocket *m_Socket = nullptr;
   std::unique_ptr<QDataStream> m_Stream;
 };

--- a/src/lib/gui/ipc/QIpcClient.h
+++ b/src/lib/gui/ipc/QIpcClient.h
@@ -48,7 +48,7 @@ private slots:
   void onRetryConnect();
   void onSocketConnected() const;
   void onIpcReaderHelloBack();
-  void onSocketError(QAbstractSocket::SocketError error) const;
+  void onSocketError(QAbstractSocket::SocketError error);
   void onIpcReaderRead(const QString &text);
 
 private:

--- a/src/lib/gui/messages.cpp
+++ b/src/lib/gui/messages.cpp
@@ -275,11 +275,12 @@ bool showClearSettings(QWidget *parent) {
 }
 
 void showReadOnlySettings(QWidget *parent, const QString &systemSettingsPath) {
+  QString nativePath = QDir::toNativeSeparators(systemSettingsPath);
   QMessageBox::information(
       parent, "Read-only settings",
       QString("<p>Settings are read-only because you only have read access "
               "to the file:</p><p>%1</p>")
-          .arg(systemSettingsPath));
+          .arg(nativePath));
 }
 
 } // namespace synergy::gui::messages

--- a/src/lib/gui/messages.cpp
+++ b/src/lib/gui/messages.cpp
@@ -149,7 +149,16 @@ void showCloseReminder(QWidget *parent) {
   QMessageBox::information(parent, "Notification area icon", message);
 }
 
-void showFirstRunMessage(
+void showFirstServerStartMessage(QWidget *parent) {
+  QMessageBox::information(
+      parent, "Server is running",
+      "<p>Great, the server is now running.</p>"
+      "<p>Now you can connect your other computers to this server. "
+      "You should see a prompt here on the server when a new client tries to "
+      "connect.</p>");
+}
+
+void showFirstConnectedMessage(
     QWidget *parent, bool closeToTray, bool enableService, bool isServer) {
 
   auto message = QString("<p>Synergy is now connected!</p>");

--- a/src/lib/gui/messages.cpp
+++ b/src/lib/gui/messages.cpp
@@ -274,4 +274,12 @@ bool showClearSettings(QWidget *parent) {
   return message.clickedButton() == clear;
 }
 
+void showReadOnlySettings(QWidget *parent, const QString &systemSettingsPath) {
+  QMessageBox::information(
+      parent, "Read-only settings",
+      QString("<p>Settings are read-only because you only have read access "
+              "to the file:</p><p>%1</p>")
+          .arg(systemSettingsPath));
+}
+
 } // namespace synergy::gui::messages

--- a/src/lib/gui/messages.h
+++ b/src/lib/gui/messages.h
@@ -50,4 +50,6 @@ showNewClientPrompt(QWidget *parent, const QString &clientName);
 
 bool showClearSettings(QWidget *parent);
 
+void showReadOnlySettings(QWidget *parent, const QString &systemSettingsPath);
+
 } // namespace synergy::gui::messages

--- a/src/lib/gui/messages.h
+++ b/src/lib/gui/messages.h
@@ -33,7 +33,9 @@ void messageHandler(
 
 void raiseCriticalDialog();
 
-void showFirstRunMessage(
+void showFirstServerStartMessage(QWidget *parent);
+
+void showFirstConnectedMessage(
     QWidget *parent, bool closeToTray, bool enableService, bool isServer);
 
 void showCloseReminder(QWidget *parent);

--- a/src/lib/gui/proxy/QSettingsProxy.cpp
+++ b/src/lib/gui/proxy/QSettingsProxy.cpp
@@ -39,7 +39,13 @@ const auto kUnixSystemConfigPath = "/usr/local/etc/";
 // Free functions
 //
 
-QString getSystemSettingPath() {
+/**
+ * @brief The base dir for the system settings file.
+ *
+ * Important: Qt will append the org name as a dir, and the app name as the
+ * settings filename, i.e.: `{base-dir}/Synergy/Synergy.ini`
+ */
+QString getSystemSettingsBaseDir() {
 #if defined(Q_OS_WIN)
   return QCoreApplication::applicationDirPath();
 #elif defined(Q_OS_UNIX)
@@ -73,7 +79,7 @@ void migrateLegacySystemSettings(QSettings &settings) {
   }
 
   QSettings::setPath(
-      QSettings::IniFormat, QSettings::SystemScope, getSystemSettingPath());
+      QSettings::IniFormat, QSettings::SystemScope, getSystemSettingsBaseDir());
 }
 
 void migrateLegacyUserSettings(QSettings &newSettings) {
@@ -149,7 +155,7 @@ void QSettingsProxy::loadSystem() {
 
   QSettings::setPath(
       QSettings::Format::IniFormat, QSettings::Scope::SystemScope,
-      getSystemSettingPath());
+      getSystemSettingsBaseDir());
 
   m_pSettings = std::make_unique<QSettings>(
       QSettings::Format::IniFormat, QSettings::Scope::SystemScope, orgName,

--- a/src/lib/gui/proxy/QSettingsProxy.cpp
+++ b/src/lib/gui/proxy/QSettingsProxy.cpp
@@ -29,6 +29,7 @@
 namespace synergy::gui::proxy {
 
 const auto kLegacyOrgDomain = "http-symless-com";
+const auto kLegacySystemConfigFilename = "SystemConfig.ini";
 
 #if defined(Q_OS_UNIX)
 const auto kUnixSystemConfigPath = "/usr/local/etc/";
@@ -58,7 +59,8 @@ void migrateLegacySystemSettings(QSettings &settings) {
   }
 
   QSettings::setPath(
-      QSettings::IniFormat, QSettings::SystemScope, kSystemConfigFilename);
+      QSettings::IniFormat, QSettings::SystemScope,
+      kLegacySystemConfigFilename);
   QSettings oldSystemSettings(
       QSettings::IniFormat, QSettings::SystemScope,
       QCoreApplication::organizationName(),

--- a/src/lib/gui/proxy/QSettingsProxy.cpp
+++ b/src/lib/gui/proxy/QSettingsProxy.cpp
@@ -30,10 +30,8 @@ namespace synergy::gui::proxy {
 
 const auto kLegacyOrgDomain = "http-symless-com";
 
-const auto kSystemConfigFilename = "SystemConfig.ini";
-
 #if defined(Q_OS_UNIX)
-const auto kUnixSystemConfigPath = "/usr/local/etc/symless/";
+const auto kUnixSystemConfigPath = "/usr/local/etc/";
 #endif
 
 //
@@ -41,14 +39,12 @@ const auto kUnixSystemConfigPath = "/usr/local/etc/symless/";
 //
 
 QString getSystemSettingPath() {
-  const QString settingFilename(kSystemConfigFilename);
 #if defined(Q_OS_WIN)
-  return QCoreApplication::applicationDirPath() + QDir::separator();
-#elif defined(Q_OS_MAC)
-  // it would be nice to use /Library dir, but qt has no elevate system.
-  return kUnixSystemConfigPath + settingFilename;
-#elif defined(Q_OS_LINUX)
-  // qt already adds application and filename to the end of the path on linux.
+  return QCoreApplication::applicationDirPath();
+#elif defined(Q_OS_UNIX)
+  // Qt already adds application and filename to the end of the path.
+  // On macOS, it would be nice to use /Library dir, but qt has no elevate
+  // system.
   return kUnixSystemConfigPath;
 #else
 #error "unsupported platform"

--- a/src/lib/gui/proxy/QSettingsProxy.h
+++ b/src/lib/gui/proxy/QSettingsProxy.h
@@ -21,7 +21,7 @@
 
 namespace synergy::gui::proxy {
 
-QString getSystemSettingPath();
+QString getSystemSettingBaseDir();
 
 class QSettingsProxy {
 public:

--- a/src/test/shared/gui/mocks/AppConfigMock.h
+++ b/src/test/shared/gui/mocks/AppConfigMock.h
@@ -42,6 +42,7 @@ public:
   // Getters
   //
 
+  MOCK_METHOD(synergy::gui::IConfigScopes &, scopes, (), (const, override));
   MOCK_METHOD(QString, tlsCertPath, (), (const, override));
   MOCK_METHOD(int, tlsKeyLength, (), (const, override));
   MOCK_METHOD(bool, tlsEnabled, (), (const, override));
@@ -76,7 +77,6 @@ public:
   // Setters
   //
 
-  MOCK_METHOD(void, setStartedBefore, (bool startedBefore), (override));
   MOCK_METHOD(
       void, setLoadFromSystemScope, (bool loadFromSystemScope), (override));
   MOCK_METHOD(void, setScreenName, (const QString &screenName), (override));

--- a/src/test/shared/gui/mocks/AppConfigMock.h
+++ b/src/test/shared/gui/mocks/AppConfigMock.h
@@ -39,7 +39,7 @@ public:
   }
 
   //
-  // Setters
+  // Getters
   //
 
   MOCK_METHOD(QString, tlsCertPath, (), (const, override));
@@ -73,9 +73,10 @@ public:
   MOCK_METHOD(bool, clientGroupChecked, (), (const, override));
 
   //
-  // Getters
+  // Setters
   //
 
+  MOCK_METHOD(void, setStartedBefore, (bool startedBefore), (override));
   MOCK_METHOD(
       void, setLoadFromSystemScope, (bool loadFromSystemScope), (override));
   MOCK_METHOD(void, setScreenName, (const QString &screenName), (override));

--- a/src/test/unittests/gui/config/AppConfigTests.cpp
+++ b/src/test/unittests/gui/config/AppConfigTests.cpp
@@ -49,6 +49,7 @@ public:
   MOCK_METHOD(const QSettingsProxy &, activeSettings, (), (const, override));
   MOCK_METHOD(QSettingsProxy &, activeSettings, (), (override));
   MOCK_METHOD(void, save, (bool), (override));
+  MOCK_METHOD(QString, activeFilePath, (), (const, override));
 };
 
 struct DepsMock : public AppConfig::Deps {


### PR DESCRIPTION
https://symless.atlassian.net/browse/S1-1744
https://symless.atlassian.net/browse/S1-1792
https://symless.atlassian.net/browse/S1-1793

Also:
- Swap assert in screen dtor for warning log lines
- Flush IPC write buffer (to fix clear settings IPC bug)
- Fixed: app has run before setting was never set
- Show message box on first server run